### PR TITLE
[vvm] fix for verizon MVNOs

### DIFF
--- a/java/com/android/voicemail/impl/res/xml/vvm_config.xml
+++ b/java/com/android/voicemail/impl/res/xml/vvm_config.xml
@@ -197,7 +197,7 @@
         </string-array>
         <int name="vvm_port_number_int" value="0" />
         <string name="vvm_destination_number_string">900080006200</string>
-        <string name="vvm_type_string">vvm_type_vvm3_mvno</string>
+        <string name="vvm_type_string">vvm_type_vvm3</string>
         <string name="vvm_client_prefix_string">//VZWVVM</string>
         <boolean name="vvm_cellular_data_required_bool" value="true" />
         <boolean name="vvm_legacy_mode_enabled_bool" value="true" />
@@ -210,7 +210,7 @@
         </string-array>
         <int name="vvm_port_number_int" value="0" />
         <string name="vvm_destination_number_string">900080006200</string>
-        <string name="vvm_type_string">vvm_type_vvm3_mvno</string>
+        <string name="vvm_type_string">vvm_type_vvm3</string>
         <string name="vvm_client_prefix_string">//VZWVVM</string>
         <boolean name="vvm_cellular_data_required_bool" value="true" />
         <boolean name="vvm_legacy_mode_enabled_bool" value="true" />
@@ -223,7 +223,7 @@
         </string-array>
         <int name="vvm_port_number_int" value="0" />
         <string name="vvm_destination_number_string">900080006200</string>
-        <string name="vvm_type_string">vvm_type_vvm3_mvno</string>
+        <string name="vvm_type_string">vvm_type_vvm3</string>
         <string name="vvm_client_prefix_string">//VZWVVM</string>
         <boolean name="vvm_cellular_data_required_bool" value="true" />
         <boolean name="vvm_legacy_mode_enabled_bool" value="true" />
@@ -236,7 +236,7 @@
         </string-array>
         <int name="vvm_port_number_int" value="0" />
         <string name="vvm_destination_number_string">900080006200</string>
-        <string name="vvm_type_string">vvm_type_vvm3_mvno</string>
+        <string name="vvm_type_string">vvm_type_vvm3</string>
         <string name="vvm_client_prefix_string">//VZWVVM</string>
         <boolean name="vvm_cellular_data_required_bool" value="true" />
         <boolean name="vvm_legacy_mode_enabled_bool" value="true" />


### PR DESCRIPTION
- moves 3-4 verizon based MVNOs back to vvm_type_vvm3
- allows voicemail notifications & VVM to work for those carriers (like straighttalk/tracfone)

I tested this by:

- Locally building with this dialer change
- flashing a Pixel 7 with the build
- putting in my SIM (straighttalk) and starting the phone app.
- Voicemail appeared and I was able to listen to older voicemails.

Guessing his should fix voicemail notifications & visual voicemail for other Verizon MVNOs (like tracfone/visible/etc.).