### PR TITLE
callrec: fix wrong call recording button state after Fragment recreation

### DIFF
--- a/java/com/android/incallui/incall/impl/ButtonController.java
+++ b/java/com/android/incallui/incall/impl/ButtonController.java
@@ -28,6 +28,7 @@ import android.text.format.DateUtils;
 import android.view.View;
 import android.view.View.OnClickListener;
 import com.android.dialer.common.Assert;
+import com.android.dialer.common.LogUtil;
 import com.android.incallui.incall.impl.CheckableLabeledButton.OnCheckedChangeListener;
 import com.android.incallui.incall.protocol.InCallButtonIds;
 import com.android.incallui.incall.protocol.InCallButtonUiDelegate;
@@ -493,6 +494,10 @@ interface ButtonController {
 
     public void setRecordingDuration(long durationMs) {
       recordingSeconds = (durationMs + 500) / 1000;
+      if (!isChecked) {
+        LogUtil.w("CallRecordButtonController.setRecordingDuration", "isChecked was false, enabling button");
+        isChecked = true;
+      }
       setButton(button);
     }
 


### PR DESCRIPTION
See point 2 of https://github.com/GrapheneOS/os-issue-tracker/issues/4307

`InCallButtonGridFragment` is destroyed and recreated in a handful of situations:

- `InCallActivity` is backgrounded for a while and eventually gets destroyed. It's recreated when the user launches the call UI again.
- `InCallButtonGridFragment#onDestroyView` is called as a result of Fragment operations. e.g. this occurs when there is a new incoming call while in an existing call

When `InCallButtonGridFragment` goes through that Fragment lifecycle, the call recording button is initialized to be unchecked even if a call recording is active and `setRecordingDuration` is still being called. The resulting bug is that the UI shows call recording is not active even if it is.

Ensure the call recording button is checked if progress updates are coming in. The button must be checked to show as active. Progress updates can only happen if there is an active recording.