### PR TITLE
callrec: add call recording V2 initially as an opt-in setting

### DIFF
--- a/java/com/android/dialer/app/res/values/strings_ext.xml
+++ b/java/com/android/dialer/app/res/values/strings_ext.xml
@@ -18,7 +18,11 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="call_recording_header_title">Call recording</string>
 
+    <string name="call_recording_use_call_recording_v2_title">Use call recording V2 (experimental)</string>
+    <string name="call_recording_use_call_recording_v2_summary">Allows WAV recording option</string>
+
     <string name="call_recording_output_format_title">Audio output format</string>
+    <string name="call_recording_output_format_title_v2">Audio output format (V2)</string>
 
     <string-array name="call_recording_output_format_entries" translatable="false">
         <item>AAC in MPEG-4 container</item>
@@ -28,6 +32,18 @@
     <string-array name="call_recording_output_format_values" translatable="false">
         <item>"0"</item>
         <item>"1"</item>
+    </string-array>
+
+    <string-array name="call_recording_output_format_entries_v2" translatable="false">
+        <item>AAC in MPEG-4 container</item>
+        <item>AMR-WB</item>
+        <item>Uncompressed PCM in WAV container</item>
+    </string-array>
+
+    <string-array name="call_recording_output_format_values_v2" translatable="false">
+        <item>"0"</item>
+        <item>"1"</item>
+        <item>"2"</item>
     </string-array>
 
     <string name="call_recording_output_format_default" translatable="false">"0"</string>

--- a/java/com/android/dialer/app/res/xml/call_recording_settings.xml
+++ b/java/com/android/dialer/app/res/xml/call_recording_settings.xml
@@ -2,13 +2,30 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
+  <SwitchPreference
+    android:key="call_recording_use_v2"
+    android:title="@string/call_recording_use_call_recording_v2_title"
+    android:summary="@string/call_recording_use_call_recording_v2_summary"
+    android:defaultValue="false"
+    android:order="0" />
+
+  <ListPreference
+    android:key="call_recording_output_format_v2"
+    android:title="@string/call_recording_output_format_title_v2"
+    android:summary="%s"
+    android:entries="@array/call_recording_output_format_entries_v2"
+    android:entryValues="@array/call_recording_output_format_values_v2"
+    android:defaultValue="@string/call_recording_output_format_default"
+    android:order="1" />
+
   <ListPreference
     android:key="call_recording_output_format"
     android:title="@string/call_recording_output_format_title"
     android:summary="%s"
     android:entries="@array/call_recording_output_format_entries"
     android:entryValues="@array/call_recording_output_format_values"
-    android:defaultValue="@string/call_recording_output_format_default" />
+    android:defaultValue="@string/call_recording_output_format_default"
+    android:order="1" />
 
   <ListPreference
     android:key="call_recording_audio_source"
@@ -16,12 +33,14 @@
     android:summary="%s"
     android:entries="@array/call_recording_audio_source_entries"
     android:entryValues="@array/call_recording_audio_source_values"
-    android:defaultValue="@string/call_recording_audio_source_default" />
+    android:defaultValue="@string/call_recording_audio_source_default"
+    android:order="2" />
 
   <Preference
     android:key="call_recording_warning"
     android:persistent="false"
     android:title="@string/call_recording_warning_settings_title"
-    android:summary="@string/recording_warning_text" />
+    android:summary="@string/recording_warning_text"
+    android:order="999" />
 
 </PreferenceScreen>

--- a/java/com/android/dialer/app/settings/CallRecordingSettingsFragment.java
+++ b/java/com/android/dialer/app/settings/CallRecordingSettingsFragment.java
@@ -1,15 +1,48 @@
 package com.android.dialer.app.settings;
 
 import android.os.Bundle;
+import android.preference.Preference;
 import android.preference.PreferenceFragment;
+import android.preference.PreferenceScreen;
+import android.preference.SwitchPreference;
+
 import com.android.dialer.app.R;
-import com.android.dialer.callrecord.impl.CallRecorderService;
 
 public class CallRecordingSettingsFragment extends PreferenceFragment {
+
+  private Preference formatV1;
+  private Preference formatV2;
+
+  private void setOutputOptionsVisibility(boolean isV2Enabled) {
+    if (isV2Enabled) {
+      hideFirstShowSecond(formatV1, formatV2);
+    } else {
+      hideFirstShowSecond(formatV2, formatV1);
+    }
+  }
+  private void hideFirstShowSecond(Preference first, Preference second) {
+    PreferenceScreen screen = getPreferenceScreen();
+    screen.removePreference(first);
+    if (screen.findPreference(second.getKey()) == null) {
+      screen.addPreference(second);
+    }
+  }
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     addPreferencesFromResource(R.xml.call_recording_settings);
+
+    final SwitchPreference useV2 = (SwitchPreference) findPreference("call_recording_use_v2");
+    formatV1 = findPreference("call_recording_output_format");
+    formatV2 = findPreference("call_recording_output_format_v2");
+
+    setOutputOptionsVisibility(useV2.isChecked());
+
+    useV2.setOnPreferenceChangeListener((preference, newValue) -> {
+      boolean isV2Enabled = (Boolean) newValue;
+      setOutputOptionsVisibility(isV2Enabled);
+      return true;
+    });
   }
 }

--- a/java/com/android/dialer/callrecord/AndroidManifest.xml
+++ b/java/com/android/dialer/callrecord/AndroidManifest.xml
@@ -22,5 +22,7 @@
   <application>
     <service android:name="com.android.dialer.callrecord.impl.CallRecorderService"
         android:process="com.android.incallui" />
+    <service android:name="com.android.dialer.callrecord.impl.CallRecorderServiceV2"
+        android:process="com.android.incallui" />
   </application>
 </manifest>

--- a/java/com/android/dialer/callrecord/impl/AmrAudioWriter.java
+++ b/java/com/android/dialer/callrecord/impl/AmrAudioWriter.java
@@ -1,0 +1,67 @@
+package com.android.dialer.callrecord.impl;
+
+import android.media.MediaFormat;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * MediaMuxer does not support AMR output despite an AMR writer being present in
+ * frameworks/av/media/libstagefright/AMRWriter.cpp. The AMR format is simple enough to write it
+ * here.
+ */
+public class AmrAudioWriter extends AudioWriter.OutputStreamAudioWriter {
+
+  private boolean mIsInit;
+
+  public AmrAudioWriter(FileDescriptor fd) {
+    super(fd);
+  }
+
+  @Override
+  public synchronized void init(MediaFormat mediaFormat) throws IOException {
+    if (mIsInit) {
+      return;
+    }
+    final int channelCount = mediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT, -1);
+    final String mime = mediaFormat.getString(MediaFormat.KEY_MIME);
+    final boolean isAmrWb = MediaFormat.MIMETYPE_AUDIO_AMR_WB.equals(mime);
+
+    final int sampleRate = mediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE, 0);
+    // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/av/media/libstagefright/data/
+    // lists expected values. AMRWriter also has these checks hardcoded:
+    // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/av/media/libstagefright/AMRWriter.cpp;l=84
+    if (isAmrWb && sampleRate != 16000) {
+      throw new IOException("invalid sampleRate for AMR-WB: " + sampleRate);
+    } else if (!isAmrWb && sampleRate != 8000) {
+      throw new IOException("invalid sampleRate for AMR: " + sampleRate);
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc4867#page-35
+    // "An AMR or AMR-WB file has the following structure:"
+    //
+    //   +------------------+
+    //   | Header           |
+    //   +------------------+
+    //   | Speech frame 1   |
+    //   +------------------+
+    //   : ...              :
+    //   +------------------+
+    //   | Speech frame n   |
+    //   +------------------+
+    writeAmrHeader(isAmrWb, channelCount);
+    mIsInit = true;
+  }
+
+  public void writeAmrHeader(boolean isAmrWb, int channelCount) throws IOException {
+    final String header;
+    if (channelCount == 1) {
+      header = isAmrWb ? "#!AMR-WB\n" : "#!AMR\n";
+    } else {
+      // https://developer.android.com/media/platform/supported-formats
+      throw new IOException("invalid channel count " + channelCount);
+    }
+    mOutputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+  }
+}

--- a/java/com/android/dialer/callrecord/impl/AudioWriter.java
+++ b/java/com/android/dialer/callrecord/impl/AudioWriter.java
@@ -9,6 +9,8 @@ import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 
 /**
  * Writes audio data, usually from android.media.MediaCodec, to storage
@@ -22,9 +24,11 @@ public abstract class AudioWriter implements AutoCloseable {
 
   public static class OutputStreamAudioWriter extends AudioWriter {
     protected final BufferedOutputStream mOutputStream;
+    protected final WritableByteChannel mChannel;
 
     public OutputStreamAudioWriter(FileDescriptor fd) {
       mOutputStream = new BufferedOutputStream(new FileOutputStream(fd));
+      mChannel = Channels.newChannel(mOutputStream);
     }
 
     @Override
@@ -33,14 +37,12 @@ public abstract class AudioWriter implements AutoCloseable {
 
     @Override
     public void write(ByteBuffer buffer, MediaCodec.BufferInfo bufferInfo) throws IOException {
-      while (buffer.hasRemaining()) {
-        mOutputStream.write(buffer.get());
-      }
+      mChannel.write(buffer);
     }
 
     @Override
     public void close() throws Exception {
-      mOutputStream.close();
+      mChannel.close();
     }
   }
 

--- a/java/com/android/dialer/callrecord/impl/AudioWriter.java
+++ b/java/com/android/dialer/callrecord/impl/AudioWriter.java
@@ -1,0 +1,80 @@
+package com.android.dialer.callrecord.impl;
+
+import android.media.MediaCodec;
+import android.media.MediaFormat;
+import android.media.MediaMuxer;
+
+import java.io.BufferedOutputStream;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Writes audio data, usually from android.media.MediaCodec, to storage
+ */
+public abstract class AudioWriter implements AutoCloseable {
+
+  public abstract void init(MediaFormat mediaFormat) throws IOException;
+
+  public abstract void write(ByteBuffer buffer, MediaCodec.BufferInfo bufferInfo)
+          throws IOException;
+
+  public static class OutputStreamAudioWriter extends AudioWriter {
+    protected final BufferedOutputStream mOutputStream;
+
+    public OutputStreamAudioWriter(FileDescriptor fd) {
+      mOutputStream = new BufferedOutputStream(new FileOutputStream(fd));
+    }
+
+    @Override
+    public void init(MediaFormat mediaFormat) throws IOException {
+    }
+
+    @Override
+    public void write(ByteBuffer buffer, MediaCodec.BufferInfo bufferInfo) throws IOException {
+      while (buffer.hasRemaining()) {
+        mOutputStream.write(buffer.get());
+      }
+    }
+
+    @Override
+    public void close() throws Exception {
+      mOutputStream.close();
+    }
+  }
+
+  public static class MediaMuxerWrapper extends AudioWriter {
+    private final MediaMuxer mMediaMuxer;
+    private int mTrackIndex;
+    private boolean isInit;
+
+    public MediaMuxerWrapper(FileDescriptor fd, int format) throws IOException {
+      mMediaMuxer = new MediaMuxer(fd, format);
+    }
+
+    @Override
+    public void init(MediaFormat mediaFormat) {
+      mTrackIndex = mMediaMuxer.addTrack(mediaFormat);
+      mMediaMuxer.start();
+      isInit = true;
+    }
+
+    @Override
+    public void write(ByteBuffer buffer, MediaCodec.BufferInfo bufferInfo) {
+      if (!isInit) {
+        throw new IllegalStateException("init not called");
+      }
+      mMediaMuxer.writeSampleData(mTrackIndex, buffer, bufferInfo);
+    }
+
+    @Override
+    public void close() throws Exception {
+      try {
+        mMediaMuxer.stop();
+      } catch (IllegalStateException ignored) {
+      }
+      mMediaMuxer.release();
+    }
+  }
+}

--- a/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
@@ -140,6 +140,8 @@ public abstract class BaseCallRecorder implements Closeable {
           runInitialRecordJob();
         } catch (Throwable t) {
           Log.e(TAG, "error when running initial record job", t);
+          mIsRecording = false;
+          mAudioBufferPool.close();
           throw t;
         }
         return null;
@@ -149,6 +151,8 @@ public abstract class BaseCallRecorder implements Closeable {
         runConsumerJob();
       } catch (Throwable t) {
         Log.e(TAG, "error when running consumer job", t);
+        mIsRecording = false;
+        mAudioBufferPool.close();
         throw t;
       }
       return null;
@@ -156,20 +160,19 @@ public abstract class BaseCallRecorder implements Closeable {
   }
 
   private void runInitialRecordJob() throws Exception {
-    mWritePfd = mContentResolver.openFileDescriptor(mUri, "w");
-    if (mWritePfd == null) {
-      throw new IOException("pfd for " + mUri + " failed to open");
-    }
-
     try {
+      mWritePfd = mContentResolver.openFileDescriptor(mUri, "w");
+      if (mWritePfd == null) {
+        throw new IOException("pfd for " + mUri + " failed to open");
+      }
+
       onRecordingStart(mWritePfd);
+      Log.d(TAG, "start recording");
+      mAudioRecord.startRecording();
     } catch (Throwable t) {
       closeWritePfd();
       throw t;
     }
-
-    Log.d(TAG, "start recording");
-    mAudioRecord.startRecording();
     mIsRecording = true;
 
     final long startTimeMs = SystemClock.elapsedRealtime();

--- a/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
@@ -11,6 +11,7 @@ import android.util.Log;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -59,7 +60,7 @@ public abstract class BaseCallRecorder implements Closeable {
             return thread;
           });
   private final ExecutorService mAudioBufferConsumerExecutor = Executors.newSingleThreadExecutor();
-  private ByteArrayPool mAudioBufArrayPool;
+  private ByteBufferPool mAudioBufferPool;
 
   @GuardedBy("this")
   private Future<?> mWritingTask;
@@ -88,7 +89,7 @@ public abstract class BaseCallRecorder implements Closeable {
                     mAudioRecord.getSampleRate(), mAudioRecord.getChannelConfiguration(),
                     mAudioRecord.getAudioFormat()));
     Log.d(TAG, "mPcmBufferSize " + mPcmBufferSize);
-    mAudioBufArrayPool = new ByteArrayPool(BUFFER_POOL_NUM_BUFFERS, mPcmBufferSize);
+    mAudioBufferPool = new ByteBufferPool(BUFFER_POOL_NUM_BUFFERS, mPcmBufferSize);
   }
 
   protected final long computePresentationTimeUs(int bytesRead) {
@@ -112,8 +113,8 @@ public abstract class BaseCallRecorder implements Closeable {
     }
 
     mBytesRead.set(0);
-    if (mAudioBufArrayPool.isClosed()) {
-      mAudioBufArrayPool = new ByteArrayPool(BUFFER_POOL_NUM_BUFFERS, mPcmBufferSize);
+    if (mAudioBufferPool.isClosed()) {
+      mAudioBufferPool = new ByteBufferPool(BUFFER_POOL_NUM_BUFFERS, mPcmBufferSize);
     }
 
     mRecordLoopJob.set(
@@ -176,7 +177,7 @@ public abstract class BaseCallRecorder implements Closeable {
     private final long mPeriodMs;
     // This might be left here if the job is cancelled, but that's fine since the pool this
     // buffer belongs to gets closed if this is cancelled anyway.
-    private ByteArrayPool.Buffer mBuffer;
+    private ByteBufferPool.Buffer mBuffer;
 
     RecordJobLoop(long startTimeMs, long periodMs) {
       mStartTimeMs = startTimeMs;
@@ -208,7 +209,7 @@ public abstract class BaseCallRecorder implements Closeable {
       Log.d(TAG, "closeQuietly: AudioRecord loop finished");
       if (mBuffer != null) {
         // not needed since we're going to close the pool and only one producer
-        mAudioBufArrayPool.release(mBuffer);
+        mAudioBufferPool.release(mBuffer);
         mBuffer = null;
       }
       stopAudioRecordResources();
@@ -240,35 +241,35 @@ public abstract class BaseCallRecorder implements Closeable {
       }
 
       if (mBuffer == null) {
-        mBuffer = mAudioBufArrayPool.acquire();
+        mBuffer = mAudioBufferPool.acquire();
         if (mBuffer == null) {
           // pool is closed
           return false;
+        } else {
+          mBuffer.data.clear();
         }
       }
 
       int read = 0;
 
-      // Google Dialer passes a byte[] instead of short[] for ENCODING_PCM_16BIT, despite this
-      // method documenting that byte[] is only for ENCODING_PCM_8BIT and that using byte[] here
-      // is deprecated.
-      read = mAudioRecord.read(mBuffer.data, 0, mBuffer.data.length,
+      // AudioRecord does not change the ByteBuffer position
+      read = mAudioRecord.read(mBuffer.data, mBuffer.data.capacity(),
               AudioRecord.READ_NON_BLOCKING);
       if (read < 0) {
-        mAudioBufArrayPool.release(mBuffer);
+        mAudioBufferPool.release(mBuffer);
         mBuffer = null;
         Log.e(TAG, "error on AudioRecord read: " + read);
         throw new IOException("error on AudioRecord read: " + read);
       } else if (read > 0) {
-        if (!mAudioBufArrayPool.produce(mBuffer, read)) {
+        if (!mAudioBufferPool.produce(mBuffer, read)) {
           // pool is closed
           return false;
         }
         mBuffer = null;
+      } else {
+        // If read == 0, keep mBuffer for the next iteration so that we don't need to acquire from
+        // pool again.
       }
-      // If we read 0 bytes, keep the buffer for the next scheduled run to avoid polling for a
-      // free one again
-
 
       return shouldContinue();
     }
@@ -284,7 +285,7 @@ public abstract class BaseCallRecorder implements Closeable {
 
   public final synchronized void stopRecordingBlocking() {
     mIsRecording = false;
-    mAudioBufArrayPool.close();
+    mAudioBufferPool.close();
     if (mWritingTask == null) {
       return;
     }
@@ -333,21 +334,21 @@ public abstract class BaseCallRecorder implements Closeable {
 
   private void runConsumerJob() throws IOException, InterruptedException {
     while (true) {
-      try (ByteArrayPool.Buffer newPcmAudio = mAudioBufArrayPool.consume()) {
+      try (ByteBufferPool.Buffer newPcmAudio = mAudioBufferPool.consume()) {
         if (newPcmAudio == null) {
           Log.d(TAG, "consumer job exit");
           break;
         }
 
-        mBytesRead.addAndGet(newPcmAudio.length);
-        onPcmBufferRead(newPcmAudio.length, newPcmAudio.data);
+        mBytesRead.addAndGet(newPcmAudio.data.limit());
+        onPcmBufferRead(newPcmAudio.data);
       }
     }
   }
 
   /**
    * Called before the buffer loop to prepare for recording. After this, the buffer reading loop is
-   * entered and {@link #onPcmBufferRead(int, byte[])} will be called repeatedly.
+   * entered and {@link #onPcmBufferRead(ByteBuffer)} will be called repeatedly.
    *
    * @param pfd A file descriptor for the call recording file in storage to write to. This is open
    *            in "w" mode, so seeking isn't possible. Do not close this.
@@ -356,15 +357,15 @@ public abstract class BaseCallRecorder implements Closeable {
   protected abstract void onRecordingStart(ParcelFileDescriptor pfd) throws IOException;
 
   /**
-   * Repeatedly called after {@link android.media.AudioRecord#read} in a loop.
+   * Repeatedly called after bytes from {@link android.media.AudioRecord#read} are read in a loop.
    * This will be called in a different thread from the thread that's reading from AudioRecord.
    *
-   * @param read The number of bytes that was read into the buffer after
-   * {@link android.media.AudioRecord#read} was called
-   * @param pcmBuffer The buffer containing PCM data from call audio
+   * @param pcmBuffer The buffer containing PCM data from call audio. The position set to 0 and
+   *                  limit is set to the number of bytes read from the
+   *                  {@link android.media.AudioRecord#read} call.
    * @throws IOException
    */
-  protected abstract void onPcmBufferRead(int read, byte[] pcmBuffer) throws IOException;
+  protected abstract void onPcmBufferRead(ByteBuffer pcmBuffer) throws IOException;
 
   /**
    * Called after recording is done and the file should be completed. The file descriptor from
@@ -393,7 +394,7 @@ public abstract class BaseCallRecorder implements Closeable {
     mIsClosed = true;
     mIsRecording = false;
     onClose();
-    mAudioBufArrayPool.close();
+    mAudioBufferPool.close();
     mAudioRecord.release();
     mAudioBufferProducerExecutor.shutdownNow();
     mAudioBufferConsumerExecutor.shutdownNow();

--- a/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
@@ -1,0 +1,200 @@
+package com.android.dialer.callrecord.impl;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.media.AudioFormat;
+import android.media.AudioRecord;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * Records audio using {@link android.media.AudioRecord} which is the same framework API that Google
+ * Dialer uses for call recording / call notes. Subclasses decide what to do with the PCM data
+ * from AudioRecord.
+ */
+public abstract class BaseCallRecorder implements Closeable {
+
+  private static final String TAG = "BaseCallRecorder";
+
+  private static final int DURATION_TO_READ_MS = 1000;
+
+  /**
+   * Whether recording is active. This is used to control the main loop in the recordingTask.
+   */
+  private volatile boolean mIsRecording;
+
+  protected final OutputFormat mOutputFormat;
+  protected final AudioFormat mAudioFormat;
+  private final AudioRecord mAudioRecord;
+  protected final ContentResolver mContentResolver;
+
+  /**
+   * The URI pointing to the call recording file that we are writing to.
+   */
+  protected final Uri mUri;
+
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+  @GuardedBy("this")
+  private Future<?> mRecordingTask;
+
+  protected BaseCallRecorder(Context context, int audioSource, Uri uri, OutputFormat outputFormat) {
+    mOutputFormat = outputFormat;
+    this.mContentResolver = context.getApplicationContext().getContentResolver();
+    this.mAudioFormat = new AudioFormat.Builder()
+            .setChannelMask(outputFormat.channelMask)
+            .setSampleRate(outputFormat.sampleRate)
+            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+            .build();
+    // Google Dialer apparently uses mAudioFormat.getSampleRate() for the AudioRecord buffer size.
+    final int bufferSizeInBytes = mAudioFormat.getSampleRate();
+    mAudioRecord = new AudioRecord(audioSource, mAudioFormat.getSampleRate(),
+            mAudioFormat.getChannelMask(), mAudioFormat.getEncoding(), bufferSizeInBytes);
+    mUri = uri;
+  }
+
+  protected final long computePresentationTimeUs(int bytesRead) {
+    int framesRead = bytesRead / mAudioFormat.getFrameSizeInBytes();
+    return (framesRead * 1_000_000L) / mAudioFormat.getSampleRate();
+  }
+
+  public final boolean isRecording() {
+    return mIsRecording && mRecordingTask != null;
+  }
+
+  public final synchronized void startRecording() {
+    if (mRecordingTask != null) {
+      Log.d(TAG, "existing recording task running");
+      return;
+    }
+    if (executorService.isShutdown()) {
+      Log.e(TAG, "cannot start recording after close() called");
+      return;
+    }
+    mRecordingTask = executorService.submit(() -> {
+      try {
+        runRecordJob();
+      } catch (Throwable t) {
+        Log.e(TAG, "error when running record job", t);
+        throw t;
+      }
+      return null;
+    });
+  }
+
+  public final synchronized void stopRecordingBlocking() {
+    mIsRecording = false;
+    if (mRecordingTask == null) {
+      return;
+    }
+    try {
+      mRecordingTask.get(5, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      Log.w(TAG, "failed to wait for recording task to finish", e);
+    }
+    mRecordingTask = null;
+  }
+
+  private void runRecordJob() throws IOException {
+    try (ParcelFileDescriptor pfd = mContentResolver.openFileDescriptor(mUri, "w")) {
+      if (pfd == null) {
+        throw new IOException("pfd for " + mUri + " failed to open");
+      }
+      onRecordingStart(pfd);
+
+      final int framesInDurationMs = mAudioRecord.getSampleRate() * DURATION_TO_READ_MS / 1000;
+
+      final int bufSize = Math.max(
+              mAudioFormat.getFrameSizeInBytes() * framesInDurationMs,
+              AudioRecord.getMinBufferSize(
+                      mAudioRecord.getSampleRate(), mAudioRecord.getChannelConfiguration(),
+                      mAudioRecord.getAudioFormat()));
+      final byte[] pcmBuffer = new byte[bufSize];
+
+      Log.d(TAG, "start recording");
+      mAudioRecord.startRecording();
+      mIsRecording = true;
+
+      int bytesRead = 0;
+      while (!Thread.currentThread().isInterrupted()
+              && mIsRecording
+              && mAudioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
+        int read = mAudioRecord.read(pcmBuffer, 0, pcmBuffer.length);
+        if (read <= 0) {
+          Log.e(TAG, "error on AudioRecord read: " + read);
+          break;
+        }
+
+        bytesRead += read;
+
+        onPcmBufferRead(bytesRead, read, pcmBuffer);
+      }
+      Log.d(TAG, "AudioRecord loop finished");
+      mAudioRecord.stop();
+      onRecordingStop();
+    } finally {
+      if (mAudioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
+        mAudioRecord.stop();
+      }
+      mIsRecording = false;
+      reset();
+    }
+  }
+
+  /**
+   * Called before the buffer loop to prepare for recording. After this, the buffer reading loop is
+   * entered and {@link #onPcmBufferRead(int, int, byte[])} will be called repeatedly.
+   *
+   * @param pfd A file descriptor for the call recording file in storage to write to. This is open
+   *            in "w" mode, so seeking isn't possible.
+   * @throws IOException if an error occurs when preparing for recording
+   */
+  protected abstract void onRecordingStart(ParcelFileDescriptor pfd) throws IOException;
+
+  /**
+   * Repeatedly called after {@link android.media.AudioRecord#read} in a loop.
+   * @param totalRead The total number of bytes read so far
+   * @param read The number of bytes that was read into the buffer after
+   * {@link android.media.AudioRecord#read} was called
+   * @param pcmBuffer The buffer containing PCM data from call audio
+   * @throws IOException
+   */
+  protected abstract void onPcmBufferRead(int totalRead, int read, byte[] pcmBuffer) throws IOException;
+
+  /**
+   * Called after recording should done and the file should be completed. The file descriptor from
+   * {@link #onRecordingStart} is still active here and will be closed after this method returns.
+   * @throws IOException
+   */
+  protected abstract void onRecordingStop() throws IOException;
+
+  /**
+   * Resets the call recorder so that {@link #startRecording()} can be called again. In practice,
+   * {@link #startRecording()} is never called again, and a new object is remade.
+   */
+  protected abstract void reset();
+
+  /**
+   * Called when subclasses should clean up resources.
+   */
+  protected abstract void onClose();
+
+  @Override
+  public final void close() {
+    mIsRecording = false;
+    onClose();
+    mAudioRecord.release();
+    executorService.shutdownNow();
+  }
+}

--- a/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
@@ -6,16 +6,23 @@ import android.media.AudioFormat;
 import android.media.AudioRecord;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
+import android.os.SystemClock;
 import android.util.Log;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.concurrent.GuardedBy;
 
@@ -29,11 +36,11 @@ public abstract class BaseCallRecorder implements Closeable {
   private static final String TAG = "BaseCallRecorder";
 
   private static final int DURATION_TO_READ_MS = 1000;
+  private static final int BUFFER_POOL_NUM_BUFFERS = 15;
+  private static final long RECORD_JOB_LOOP_PERIOD_MS = 10;
 
-  /**
-   * Whether recording is active. This is used to control the main loop in the recordingTask.
-   */
   private volatile boolean mIsRecording;
+  private volatile boolean mIsClosed;
 
   protected final OutputFormat mOutputFormat;
   protected final AudioFormat mAudioFormat;
@@ -45,12 +52,23 @@ public abstract class BaseCallRecorder implements Closeable {
    */
   protected final Uri mUri;
 
-  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+  private final ScheduledExecutorService mAudioBufferProducerExecutor =
+          Executors.newSingleThreadScheduledExecutor(r -> {
+            final Thread thread = new Thread(r, "AudioRec-HighPrio");
+            thread.setPriority(Thread.NORM_PRIORITY + 1);
+            return thread;
+          });
+  private final ExecutorService mAudioBufferConsumerExecutor = Executors.newSingleThreadExecutor();
+  private ByteArrayPool mAudioBufArrayPool;
+
   @GuardedBy("this")
-  private Future<?> mRecordingTask;
+  private Future<?> mWritingTask;
+
+  private final int mPcmBufferSize;
 
   protected BaseCallRecorder(Context context, int audioSource, Uri uri, OutputFormat outputFormat) {
     mOutputFormat = outputFormat;
+
     this.mContentResolver = context.getApplicationContext().getContentResolver();
     this.mAudioFormat = new AudioFormat.Builder()
             .setChannelMask(outputFormat.channelMask)
@@ -62,6 +80,15 @@ public abstract class BaseCallRecorder implements Closeable {
     mAudioRecord = new AudioRecord(audioSource, mAudioFormat.getSampleRate(),
             mAudioFormat.getChannelMask(), mAudioFormat.getEncoding(), bufferSizeInBytes);
     mUri = uri;
+
+    final int framesInDurationMs = mAudioRecord.getSampleRate() * DURATION_TO_READ_MS / 1000;
+    mPcmBufferSize = Math.max(
+            mAudioFormat.getFrameSizeInBytes() * framesInDurationMs,
+            AudioRecord.getMinBufferSize(
+                    mAudioRecord.getSampleRate(), mAudioRecord.getChannelConfiguration(),
+                    mAudioRecord.getAudioFormat()));
+    Log.d(TAG, "mPcmBufferSize " + mPcmBufferSize);
+    mAudioBufArrayPool = new ByteArrayPool(BUFFER_POOL_NUM_BUFFERS, mPcmBufferSize);
   }
 
   protected final long computePresentationTimeUs(int bytesRead) {
@@ -70,118 +97,286 @@ public abstract class BaseCallRecorder implements Closeable {
   }
 
   public final boolean isRecording() {
-    return mIsRecording && mRecordingTask != null;
+    return mIsRecording && mWritingTask != null;
   }
 
   public final synchronized void startRecording() {
-    if (mRecordingTask != null) {
+    if (mWritingTask != null) {
       Log.d(TAG, "existing recording task running");
       return;
     }
-    if (executorService.isShutdown()) {
+    if (mIsClosed || mAudioBufferConsumerExecutor.isShutdown()
+            || mAudioBufferProducerExecutor.isShutdown() ) {
       Log.e(TAG, "cannot start recording after close() called");
       return;
     }
-    mRecordingTask = executorService.submit(() -> {
+
+    mBytesRead.set(0);
+    if (mAudioBufArrayPool.isClosed()) {
+      mAudioBufArrayPool = new ByteArrayPool(BUFFER_POOL_NUM_BUFFERS, mPcmBufferSize);
+    }
+
+    mRecordLoopJob.set(
+      mAudioBufferProducerExecutor.schedule(() -> {
+        try {
+          runInitialRecordJob();
+        } catch (Throwable t) {
+          Log.e(TAG, "error when running initial record job", t);
+          throw t;
+        }
+        return null;
+      }, 0, TimeUnit.MILLISECONDS));
+    mWritingTask = mAudioBufferConsumerExecutor.submit(() -> {
       try {
-        runRecordJob();
+        runConsumerJob();
       } catch (Throwable t) {
-        Log.e(TAG, "error when running record job", t);
+        Log.e(TAG, "error when running consumer job", t);
         throw t;
       }
       return null;
     });
   }
 
+  private ParcelFileDescriptor mWritePfd;
+  private final AtomicReference<ScheduledFuture<?>> mRecordLoopJob = new AtomicReference<>(null);
+
+  private void runInitialRecordJob() throws Exception {
+    mWritePfd = mContentResolver.openFileDescriptor(mUri, "w");
+    if (mWritePfd == null) {
+      throw new IOException("pfd for " + mUri + " failed to open");
+    }
+
+    try {
+      onRecordingStart(mWritePfd);
+    } catch (Throwable t) {
+      try {
+        mWritePfd.close();
+      } catch (IOException ignored) {
+      }
+      throw t;
+    }
+
+    Log.d(TAG, "start recording");
+    mAudioRecord.startRecording();
+    mIsRecording = true;
+
+    final long startTimeMs = SystemClock.elapsedRealtime();
+    new RecordJobLoop(startTimeMs, RECORD_JOB_LOOP_PERIOD_MS).call();
+  }
+
+  /**
+   * A job reads from AudioRecord periodically via {@link #mAudioBufferProducerExecutor}.
+   * This roughly follows Google Dialer logic, although it's not clear why they don't use
+   * {@link ScheduledExecutorService#scheduleAtFixedRate}. Perhaps because of
+   * https://github.com/GrapheneOS/platform_libcore/commit/b1c2d048e84146ed5d17d72ab633f06faa9a2869
+   * or some other reason.
+   */
+  class RecordJobLoop implements Callable<Object> {
+    private final long mStartTimeMs;
+    private final long mPeriodMs;
+    // This might be left here if the job is cancelled, but that's fine since the pool this
+    // buffer belongs to gets closed if this is cancelled anyway.
+    private ByteArrayPool.Buffer mBuffer;
+
+    RecordJobLoop(long startTimeMs, long periodMs) {
+      mStartTimeMs = startTimeMs;
+      mPeriodMs = periodMs;
+    }
+
+    /**
+     * Computes an aligned delay based on starting at mStartTime modulo the period. The purpose is
+     * to ensure that the loop is executed only at the times `startTime + k*period`
+     */
+    private long computeAlignedDelayMs() {
+      if (mPeriodMs <= 0) return 0L;
+      long now = SystemClock.elapsedRealtime();
+      if (now < mStartTimeMs) {
+        return (mStartTimeMs + mPeriodMs) - now;
+      }
+
+      // align at next slot at startTime + k*period
+      long elapsedSinceStart = now - mStartTimeMs;
+      long remainder = elapsedSinceStart % mPeriodMs;
+      return remainder == 0 ? mPeriodMs : mPeriodMs - remainder;
+    }
+
+    private boolean shouldContinue() {
+      return mIsRecording && mAudioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING;
+    }
+
+    private void closeQuietly() {
+      Log.d(TAG, "closeQuietly: AudioRecord loop finished");
+      if (mBuffer != null) {
+        // not needed since we're going to close the pool and only one producer
+        mAudioBufArrayPool.release(mBuffer);
+        mBuffer = null;
+      }
+      stopAudioRecordResources();
+    }
+
+    @Override
+    public Object call() throws Exception {
+      try {
+        final boolean shouldContinue = callInner();
+        if (shouldContinue) {
+          // since we use AudioRecord.READ_NON_BLOCKING, reschedule periodically
+          long delay = computeAlignedDelayMs();
+          mRecordLoopJob.set(
+                  mAudioBufferProducerExecutor.schedule(this, delay, TimeUnit.MILLISECONDS));
+        } else {
+          closeQuietly();
+        }
+      } catch (Throwable t) {
+        closeQuietly();
+        throw t;
+      }
+      return null;
+    }
+
+    // Returns whether we should continue periodically
+    public boolean callInner() throws Exception {
+      if (!shouldContinue()) {
+        return false;
+      }
+
+      if (mBuffer == null) {
+        mBuffer = mAudioBufArrayPool.acquire();
+        if (mBuffer == null) {
+          // pool is closed
+          return false;
+        }
+      }
+
+      int read = 0;
+
+      // Google Dialer passes a byte[] instead of short[] for ENCODING_PCM_16BIT, despite this
+      // method documenting that byte[] is only for ENCODING_PCM_8BIT and that using byte[] here
+      // is deprecated.
+      read = mAudioRecord.read(mBuffer.data, 0, mBuffer.data.length,
+              AudioRecord.READ_NON_BLOCKING);
+      if (read < 0) {
+        mAudioBufArrayPool.release(mBuffer);
+        mBuffer = null;
+        Log.e(TAG, "error on AudioRecord read: " + read);
+        throw new IOException("error on AudioRecord read: " + read);
+      } else if (read > 0) {
+        if (!mAudioBufArrayPool.produce(mBuffer, read)) {
+          // pool is closed
+          return false;
+        }
+        mBuffer = null;
+      }
+      // If we read 0 bytes, keep the buffer for the next scheduled run to avoid polling for a
+      // free one again
+
+
+      return shouldContinue();
+    }
+  }
+
+  private void stopAudioRecordResources() {
+    try {
+      mAudioRecord.stop();
+    } catch (IllegalStateException e) {
+    }
+    mAudioBufferPool.close();
+  }
+
   public final synchronized void stopRecordingBlocking() {
     mIsRecording = false;
-    if (mRecordingTask == null) {
+    mAudioBufArrayPool.close();
+    if (mWritingTask == null) {
       return;
     }
     try {
-      mRecordingTask.get(5, TimeUnit.SECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      Log.w(TAG, "failed to wait for recording task to finish", e);
+      mWritingTask.get(5, TimeUnit.SECONDS);
+    } catch (ExecutionException | TimeoutException e) {
+      Log.w(TAG, "failed to wait for writing task to finish", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
-    mRecordingTask = null;
+    mWritingTask = null;
+
+    final ScheduledFuture<?> recordLoopJob = mRecordLoopJob.getAndSet(null);
+    if (recordLoopJob == null) {
+      return;
+    }
+    recordLoopJob.cancel(false);
+    try {
+      recordLoopJob.get(5, TimeUnit.SECONDS);
+    } catch (CancellationException ignored) {
+      // good
+    } catch (ExecutionException | TimeoutException e) {
+      Log.w(TAG, "failed to wait for recording task to finish", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    Log.d(TAG, "stopRecordingBlocking finished waiting for tasks");
+    stopAudioRecordResources();
+    try {
+      onRecordingStop();
+    } catch (IOException e) {
+      Log.e(TAG, "error in onRecordingStop", e);
+    } finally {
+      if (mWritePfd != null) {
+        try {
+          mWritePfd.close();
+        } catch (IOException ignored) {
+        }
+      }
+      reset();
+    }
   }
 
-  private void runRecordJob() throws IOException {
-    try (ParcelFileDescriptor pfd = mContentResolver.openFileDescriptor(mUri, "w")) {
-      if (pfd == null) {
-        throw new IOException("pfd for " + mUri + " failed to open");
-      }
-      onRecordingStart(pfd);
+  protected final AtomicInteger mBytesRead = new AtomicInteger(0);
 
-      final int framesInDurationMs = mAudioRecord.getSampleRate() * DURATION_TO_READ_MS / 1000;
-
-      final int bufSize = Math.max(
-              mAudioFormat.getFrameSizeInBytes() * framesInDurationMs,
-              AudioRecord.getMinBufferSize(
-                      mAudioRecord.getSampleRate(), mAudioRecord.getChannelConfiguration(),
-                      mAudioRecord.getAudioFormat()));
-      final byte[] pcmBuffer = new byte[bufSize];
-
-      Log.d(TAG, "start recording");
-      mAudioRecord.startRecording();
-      mIsRecording = true;
-
-      int bytesRead = 0;
-      while (!Thread.currentThread().isInterrupted()
-              && mIsRecording
-              && mAudioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
-        int read = mAudioRecord.read(pcmBuffer, 0, pcmBuffer.length);
-        if (read <= 0) {
-          Log.e(TAG, "error on AudioRecord read: " + read);
+  private void runConsumerJob() throws IOException, InterruptedException {
+    while (true) {
+      try (ByteArrayPool.Buffer newPcmAudio = mAudioBufArrayPool.consume()) {
+        if (newPcmAudio == null) {
+          Log.d(TAG, "consumer job exit");
           break;
         }
 
-        bytesRead += read;
-
-        onPcmBufferRead(bytesRead, read, pcmBuffer);
+        mBytesRead.addAndGet(newPcmAudio.length);
+        onPcmBufferRead(newPcmAudio.length, newPcmAudio.data);
       }
-      Log.d(TAG, "AudioRecord loop finished");
-      mAudioRecord.stop();
-      onRecordingStop();
-    } finally {
-      if (mAudioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
-        mAudioRecord.stop();
-      }
-      mIsRecording = false;
-      reset();
     }
   }
 
   /**
    * Called before the buffer loop to prepare for recording. After this, the buffer reading loop is
-   * entered and {@link #onPcmBufferRead(int, int, byte[])} will be called repeatedly.
+   * entered and {@link #onPcmBufferRead(int, byte[])} will be called repeatedly.
    *
    * @param pfd A file descriptor for the call recording file in storage to write to. This is open
-   *            in "w" mode, so seeking isn't possible.
+   *            in "w" mode, so seeking isn't possible. Do not close this.
    * @throws IOException if an error occurs when preparing for recording
    */
   protected abstract void onRecordingStart(ParcelFileDescriptor pfd) throws IOException;
 
   /**
    * Repeatedly called after {@link android.media.AudioRecord#read} in a loop.
-   * @param totalRead The total number of bytes read so far
+   * This will be called in a different thread from the thread that's reading from AudioRecord.
+   *
    * @param read The number of bytes that was read into the buffer after
    * {@link android.media.AudioRecord#read} was called
    * @param pcmBuffer The buffer containing PCM data from call audio
    * @throws IOException
    */
-  protected abstract void onPcmBufferRead(int totalRead, int read, byte[] pcmBuffer) throws IOException;
+  protected abstract void onPcmBufferRead(int read, byte[] pcmBuffer) throws IOException;
 
   /**
-   * Called after recording should done and the file should be completed. The file descriptor from
-   * {@link #onRecordingStart} is still active here and will be closed after this method returns.
+   * Called after recording is done and the file should be completed. The file descriptor from
+   * {@link #onRecordingStart} is still active here and will be closed after this method returns, so
+   * any resources using that file descriptor can still use it.
    * @throws IOException
    */
   protected abstract void onRecordingStop() throws IOException;
 
   /**
    * Resets the call recorder so that {@link #startRecording()} can be called again. In practice,
-   * {@link #startRecording()} is never called again, and a new object is remade.
+   * {@link #startRecording()} is never called again, and a new BaseCallRecorder is remade.
    */
   protected abstract void reset();
 
@@ -192,9 +387,21 @@ public abstract class BaseCallRecorder implements Closeable {
 
   @Override
   public final void close() {
+    if (mIsClosed) {
+      return;
+    }
+    mIsClosed = true;
     mIsRecording = false;
     onClose();
+    mAudioBufArrayPool.close();
     mAudioRecord.release();
-    executorService.shutdownNow();
+    mAudioBufferProducerExecutor.shutdownNow();
+    mAudioBufferConsumerExecutor.shutdownNow();
+    if (mWritePfd != null) {
+      try {
+        mWritePfd.close();
+      } catch (IOException ignored) {
+      }
+    }
   }
 }

--- a/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/BaseCallRecorder.java
@@ -31,6 +31,14 @@ import javax.annotation.concurrent.GuardedBy;
  * Records audio using {@link android.media.AudioRecord} which is the same framework API that Google
  * Dialer uses for call recording / call notes. Subclasses decide what to do with the PCM data
  * from AudioRecord.
+ * <p>
+ * Recording is done with two threads in a producer-consumer pattern. One thread calls
+ * {@link AudioRecord#read(ByteBuffer, int)} and pushes the data to a pool of pre-allocated
+ * {@link ByteBuffer}s. The other thread consumes these buffers from the pool and processes them via
+ * {@link #onPcmBufferRead(ByteBuffer)} which is implemented by subclasses.
+ * <p>
+ * To signal recording stop, the pool is closed. The consumer thread continues consuming filled
+ * buffers until there are no more, and the producer thread exits.
  */
 public abstract class BaseCallRecorder implements Closeable {
 
@@ -39,6 +47,7 @@ public abstract class BaseCallRecorder implements Closeable {
   private static final int DURATION_TO_READ_MS = 1000;
   private static final int BUFFER_POOL_NUM_BUFFERS = 15;
   private static final long RECORD_JOB_LOOP_PERIOD_MS = 10;
+  private static final long JOB_JOIN_TIMEOUT_SECONDS = 5;
 
   private volatile boolean mIsRecording;
   private volatile boolean mIsClosed;
@@ -47,23 +56,31 @@ public abstract class BaseCallRecorder implements Closeable {
   protected final AudioFormat mAudioFormat;
   private final AudioRecord mAudioRecord;
   protected final ContentResolver mContentResolver;
+  private ParcelFileDescriptor mWritePfd;
 
   /**
    * The URI pointing to the call recording file that we are writing to.
    */
   protected final Uri mUri;
-
+  // If we need more audio processing tasks in the future during a call, we can refactor this as a
+  // parameter in the constructor and put this executor elsewhere. Also, if we want to support
+  // recording both VOICE_UPLINK and VOICE_DONWLINK simultaneously, this will also work for that.
   private final ScheduledExecutorService mAudioBufferProducerExecutor =
           Executors.newSingleThreadScheduledExecutor(r -> {
-            final Thread thread = new Thread(r, "AudioRec-HighPrio");
-            thread.setPriority(Thread.NORM_PRIORITY + 1);
+            final Thread thread = new Thread(r, "AudioRec");
+            thread.setPriority(Thread.NORM_PRIORITY);
             return thread;
           });
   private final ExecutorService mAudioBufferConsumerExecutor = Executors.newSingleThreadExecutor();
+  /**
+   * Pre-allocated ByteBuffers for use by consumer and producer tasks. Closing this pool will get
+   * the producer and consumer threads to stop (consumer will consume remaining buffers until empty).
+   */
   private ByteBufferPool mAudioBufferPool;
 
   @GuardedBy("this")
   private Future<?> mWritingTask;
+  private final AtomicReference<ScheduledFuture<?>> mRecordLoopJob = new AtomicReference<>(null);
 
   private final int mPcmBufferSize;
 
@@ -138,9 +155,6 @@ public abstract class BaseCallRecorder implements Closeable {
     });
   }
 
-  private ParcelFileDescriptor mWritePfd;
-  private final AtomicReference<ScheduledFuture<?>> mRecordLoopJob = new AtomicReference<>(null);
-
   private void runInitialRecordJob() throws Exception {
     mWritePfd = mContentResolver.openFileDescriptor(mUri, "w");
     if (mWritePfd == null) {
@@ -150,10 +164,7 @@ public abstract class BaseCallRecorder implements Closeable {
     try {
       onRecordingStart(mWritePfd);
     } catch (Throwable t) {
-      try {
-        mWritePfd.close();
-      } catch (IOException ignored) {
-      }
+      closeWritePfd();
       throw t;
     }
 
@@ -162,24 +173,33 @@ public abstract class BaseCallRecorder implements Closeable {
     mIsRecording = true;
 
     final long startTimeMs = SystemClock.elapsedRealtime();
-    new RecordJobLoop(startTimeMs, RECORD_JOB_LOOP_PERIOD_MS).call();
+    new AudioRecordPeriodicProducerJob(startTimeMs, RECORD_JOB_LOOP_PERIOD_MS).call();
   }
 
   /**
    * A job reads from AudioRecord periodically via {@link #mAudioBufferProducerExecutor}.
-   * This roughly follows Google Dialer logic, although it's not clear why they don't use
-   * {@link ScheduledExecutorService#scheduleAtFixedRate}. Perhaps because of
+   * This roughly follows Google Dialer logic for reading from AudioRecord, although it's not clear
+   * why they don't use {@link ScheduledExecutorService#scheduleAtFixedRate}. Perhaps because of
    * https://github.com/GrapheneOS/platform_libcore/commit/b1c2d048e84146ed5d17d72ab633f06faa9a2869
-   * or some other reason.
+   * or it doesn't have the aligned delay semantics.
+   * <p>
+   * Although it would've been simpler to use Thread.sleep, using an Executor makes it more flexible
+   * in case we need other audio processing tasks in the future.
+   * <p>
+   * Note that if this task is cancelled while it is scheduled to run, the AudioRecord instance is
+   * not stopped. {@link #stopAudioRecordResourcesAndClosePool} or similar should be called in the
+   * same callsite where this job is cancelled in order to stop the AudioRecord instance. Could be
+   * made simpler with something like ListenableFutures from Guava or with Kotlin coroutines, but it
+   * was written this way to be close to the Google Dialer logic without importing more dependencies
    */
-  class RecordJobLoop implements Callable<Object> {
+  class AudioRecordPeriodicProducerJob implements Callable<Object> {
     private final long mStartTimeMs;
     private final long mPeriodMs;
     // This might be left here if the job is cancelled, but that's fine since the pool this
     // buffer belongs to gets closed if this is cancelled anyway.
     private ByteBufferPool.Buffer mBuffer;
 
-    RecordJobLoop(long startTimeMs, long periodMs) {
+    AudioRecordPeriodicProducerJob(long startTimeMs, long periodMs) {
       mStartTimeMs = startTimeMs;
       mPeriodMs = periodMs;
     }
@@ -206,36 +226,39 @@ public abstract class BaseCallRecorder implements Closeable {
     }
 
     private void closeQuietly() {
-      Log.d(TAG, "closeQuietly: AudioRecord loop finished");
+      mIsRecording = false;
       if (mBuffer != null) {
         // not needed since we're going to close the pool and only one producer
         mAudioBufferPool.release(mBuffer);
         mBuffer = null;
       }
-      stopAudioRecordResources();
+      stopAudioRecordResourcesAndClosePool();
     }
 
     @Override
     public Object call() throws Exception {
+      boolean shouldContinue = false;
       try {
-        final boolean shouldContinue = callInner();
+        shouldContinue = readAudioRecordAndProduceAudioData();
         if (shouldContinue) {
           // since we use AudioRecord.READ_NON_BLOCKING, reschedule periodically
           long delay = computeAlignedDelayMs();
           mRecordLoopJob.set(
                   mAudioBufferProducerExecutor.schedule(this, delay, TimeUnit.MILLISECONDS));
-        } else {
+        }
+      } finally {
+        if (!shouldContinue) {
+          Log.d(TAG, "AudioRecord loop finished");
+          // This is an opportunistic cleanup. If this job is cancelled while it is scheduled to
+          // run, this code does not run.
           closeQuietly();
         }
-      } catch (Throwable t) {
-        closeQuietly();
-        throw t;
       }
       return null;
     }
 
     // Returns whether we should continue periodically
-    public boolean callInner() throws Exception {
+    public boolean readAudioRecordAndProduceAudioData() throws Exception {
       if (!shouldContinue()) {
         return false;
       }
@@ -250,17 +273,14 @@ public abstract class BaseCallRecorder implements Closeable {
         }
       }
 
-      int read = 0;
-
       // AudioRecord does not change the ByteBuffer position
-      read = mAudioRecord.read(mBuffer.data, mBuffer.data.capacity(),
+      int read = mAudioRecord.read(mBuffer.data, mBuffer.data.capacity(),
               AudioRecord.READ_NON_BLOCKING);
       if (read < 0) {
-        mAudioBufferPool.release(mBuffer);
-        mBuffer = null;
         Log.e(TAG, "error on AudioRecord read: " + read);
-        throw new IOException("error on AudioRecord read: " + read);
+        return false;
       } else if (read > 0) {
+        // This will set buffer's limit and reset position
         if (!mAudioBufferPool.produce(mBuffer, read)) {
           // pool is closed
           return false;
@@ -275,22 +295,26 @@ public abstract class BaseCallRecorder implements Closeable {
     }
   }
 
-  private void stopAudioRecordResources() {
+  private void stopAudioRecordResourcesAndClosePool() {
     try {
       mAudioRecord.stop();
-    } catch (IllegalStateException e) {
+    } catch (IllegalStateException ignored) {
     }
+    // After the pool is closed, the consumer thread will continue until no more buffers left to
+    // process. The producer thread will stop repeating.
     mAudioBufferPool.close();
   }
 
   public final synchronized void stopRecordingBlocking() {
     mIsRecording = false;
+    // This will signal to the consumer and producer threads to stop processing.
     mAudioBufferPool.close();
     if (mWritingTask == null) {
       return;
     }
     try {
-      mWritingTask.get(5, TimeUnit.SECONDS);
+      // Allow writer task to finish processing all buffers that were pushed to the pool
+      mWritingTask.get(JOB_JOIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     } catch (ExecutionException | TimeoutException e) {
       Log.w(TAG, "failed to wait for writing task to finish", e);
     } catch (InterruptedException e) {
@@ -304,7 +328,7 @@ public abstract class BaseCallRecorder implements Closeable {
     }
     recordLoopJob.cancel(false);
     try {
-      recordLoopJob.get(5, TimeUnit.SECONDS);
+      recordLoopJob.get(JOB_JOIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     } catch (CancellationException ignored) {
       // good
     } catch (ExecutionException | TimeoutException e) {
@@ -314,18 +338,13 @@ public abstract class BaseCallRecorder implements Closeable {
     }
 
     Log.d(TAG, "stopRecordingBlocking finished waiting for tasks");
-    stopAudioRecordResources();
+    stopAudioRecordResourcesAndClosePool();
     try {
       onRecordingStop();
     } catch (IOException e) {
       Log.e(TAG, "error in onRecordingStop", e);
     } finally {
-      if (mWritePfd != null) {
-        try {
-          mWritePfd.close();
-        } catch (IOException ignored) {
-        }
-      }
+      closeWritePfd();
       reset();
     }
   }
@@ -336,6 +355,7 @@ public abstract class BaseCallRecorder implements Closeable {
     while (true) {
       try (ByteBufferPool.Buffer newPcmAudio = mAudioBufferPool.consume()) {
         if (newPcmAudio == null) {
+          // The pool is closed AND there are no more buffers to consume anymore.
           Log.d(TAG, "consumer job exit");
           break;
         }
@@ -386,6 +406,17 @@ public abstract class BaseCallRecorder implements Closeable {
    */
   protected abstract void onClose();
 
+  private void closeWritePfd() {
+    final ParcelFileDescriptor pfd = mWritePfd;
+    if (pfd != null) {
+      try {
+        pfd.close();
+      } catch (IOException ignored) {
+      }
+      mWritePfd = null;
+    }
+  }
+
   @Override
   public final void close() {
     if (mIsClosed) {
@@ -398,11 +429,6 @@ public abstract class BaseCallRecorder implements Closeable {
     mAudioRecord.release();
     mAudioBufferProducerExecutor.shutdownNow();
     mAudioBufferConsumerExecutor.shutdownNow();
-    if (mWritePfd != null) {
-      try {
-        mWritePfd.close();
-      } catch (IOException ignored) {
-      }
-    }
+    closeWritePfd();
   }
 }

--- a/java/com/android/dialer/callrecord/impl/ByteArrayPool.java
+++ b/java/com/android/dialer/callrecord/impl/ByteArrayPool.java
@@ -1,0 +1,140 @@
+package com.android.dialer.callrecord.impl;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * Fixed-size pool of reusable byte[] buffers
+ */
+public final class ByteArrayPool {
+  public final class Buffer implements AutoCloseable {
+    public final byte[] data;
+    public int length;
+    private boolean released;
+
+    private Buffer(byte[] data) {
+      this.data = data;
+      this.released = true;
+    }
+
+    @Override
+    public void close() {
+      if (released) {
+        return;
+      }
+      released = true;
+      ByteArrayPool.this.release(this);
+    }
+  }
+
+  @GuardedBy("mLock")
+  private final ArrayDeque<Buffer> mFree;
+  @GuardedBy("mLock")
+  private final ArrayDeque<Buffer> mFilled;
+  private final ReentrantLock mLock = new ReentrantLock();
+  private final Condition mNotEmpty = mLock.newCondition();
+  private final Condition mHasFree = mLock.newCondition();
+  @GuardedBy("mLock")
+  private boolean mClosed;
+
+  public ByteArrayPool(int poolSize, int bufferSize) {
+    mFree = new ArrayDeque<>(poolSize);
+    mFilled = new ArrayDeque<>(poolSize);
+    for (int i = 0; i < poolSize; i++) {
+      mFree.addLast(new Buffer(new byte[bufferSize]));
+    }
+  }
+
+  /** Producer: get a free buffer to fill. If null is returned, buffer is closed */
+  public Buffer acquire() throws InterruptedException {
+    mLock.lock();
+    try {
+      while (mFree.isEmpty() && !mClosed) {
+        mHasFree.await();
+      }
+      // If it is closed, don't allow producer to get a buffer
+      if (mClosed) {
+        return null;
+      }
+      Buffer buffer = mFree.removeFirst();
+      buffer.released = false;
+      return buffer;
+    } finally {
+      mLock.unlock();
+    }
+  }
+
+  /** Producer: hand off a filled buffer. */
+  public boolean produce(Buffer buffer, int length) {
+    if (length <= 0) {
+      return release(buffer);
+    }
+
+    mLock.lock();
+    try {
+      if (mClosed) {
+        return false;
+      }
+      buffer.length = length;
+      mFilled.addLast(buffer);
+      mNotEmpty.signal();
+      return true;
+    } finally {
+      mLock.unlock();
+    }
+  }
+
+  /** Consumer: take a filled buffer. Returns null if closed and empty. */
+  public Buffer consume() throws InterruptedException {
+    mLock.lock();
+    try {
+      while (mFilled.isEmpty() && !mClosed) {
+        mNotEmpty.await();
+      }
+      // If it is closed, don't check for mClosed so that we drain the filled buffers first
+      if (mFilled.isEmpty()) {
+        return null;
+      }
+      Buffer buffer = mFilled.removeFirst();
+      buffer.released = false;
+      return buffer;
+    } finally {
+      mLock.unlock();
+    }
+  }
+
+  /** Consumer: return a buffer to the free pool. */
+  public boolean release(Buffer buffer) {
+    mLock.lock();
+    try {
+      if (mClosed) {
+        return false;
+      }
+      buffer.length = 0;
+      // Arrays.fill(buffer.data, (byte) 0);
+      mFree.addLast(buffer);
+      mHasFree.signal();
+      return true;
+    } finally {
+      mLock.unlock();
+    }
+  }
+
+  public void close() {
+    mLock.lock();
+    try {
+      mClosed = true;
+      mNotEmpty.signalAll();
+      mHasFree.signalAll();
+    } finally {
+      mLock.unlock();
+    }
+  }
+
+  public boolean isClosed() {
+    return mClosed;
+  }
+}

--- a/java/com/android/dialer/callrecord/impl/ByteBufferPool.java
+++ b/java/com/android/dialer/callrecord/impl/ByteBufferPool.java
@@ -1,5 +1,6 @@
 package com.android.dialer.callrecord.impl;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -7,15 +8,14 @@ import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
- * Fixed-size pool of reusable byte[] buffers
+ * Fixed-size pool of reusable ByteBuffers
  */
-public final class ByteArrayPool {
+public final class ByteBufferPool {
   public final class Buffer implements AutoCloseable {
-    public final byte[] data;
-    public int length;
+    public final ByteBuffer data;
     private boolean released;
 
-    private Buffer(byte[] data) {
+    private Buffer(ByteBuffer data) {
       this.data = data;
       this.released = true;
     }
@@ -26,7 +26,7 @@ public final class ByteArrayPool {
         return;
       }
       released = true;
-      ByteArrayPool.this.release(this);
+      ByteBufferPool.this.release(this);
     }
   }
 
@@ -38,13 +38,13 @@ public final class ByteArrayPool {
   private final Condition mNotEmpty = mLock.newCondition();
   private final Condition mHasFree = mLock.newCondition();
   @GuardedBy("mLock")
-  private boolean mClosed;
+  private volatile boolean mClosed;
 
-  public ByteArrayPool(int poolSize, int bufferSize) {
+  public ByteBufferPool(int poolSize, int bufferSize) {
     mFree = new ArrayDeque<>(poolSize);
     mFilled = new ArrayDeque<>(poolSize);
     for (int i = 0; i < poolSize; i++) {
-      mFree.addLast(new Buffer(new byte[bufferSize]));
+      mFree.addLast(new Buffer(ByteBuffer.allocateDirect(bufferSize)));
     }
   }
 
@@ -78,7 +78,8 @@ public final class ByteArrayPool {
       if (mClosed) {
         return false;
       }
-      buffer.length = length;
+      buffer.data.limit(length);
+      buffer.data.position(0);
       mFilled.addLast(buffer);
       mNotEmpty.signal();
       return true;
@@ -87,7 +88,10 @@ public final class ByteArrayPool {
     }
   }
 
-  /** Consumer: take a filled buffer. Returns null if closed and empty. */
+  /**
+   * Consumer: take a filled buffer. The position is set to 0 and limit is set appropriately.
+   * Returns null if closed and empty.
+   */
   public Buffer consume() throws InterruptedException {
     mLock.lock();
     try {
@@ -113,8 +117,7 @@ public final class ByteArrayPool {
       if (mClosed) {
         return false;
       }
-      buffer.length = 0;
-      // Arrays.fill(buffer.data, (byte) 0);
+      buffer.data.clear();
       mFree.addLast(buffer);
       mHasFree.signal();
       return true;

--- a/java/com/android/dialer/callrecord/impl/ByteBufferPool.java
+++ b/java/com/android/dialer/callrecord/impl/ByteBufferPool.java
@@ -90,7 +90,8 @@ public final class ByteBufferPool {
 
   /**
    * Consumer: take a filled buffer. The position is set to 0 and limit is set appropriately.
-   * Returns null if closed and empty.
+   * Returns null if closed and empty. If the pool is closed, there may still be buffers left to
+   * consume.
    */
   public Buffer consume() throws InterruptedException {
     mLock.lock();

--- a/java/com/android/dialer/callrecord/impl/CallRecorderService.java
+++ b/java/com/android/dialer/callrecord/impl/CallRecorderService.java
@@ -16,6 +16,8 @@
 
 package com.android.dialer.callrecord.impl;
 
+import static java.lang.Integer.parseInt;
+
 import android.app.Service;
 import android.content.ContentUris;
 import android.content.Intent;
@@ -30,6 +32,7 @@ import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.android.dialer.R;
 import com.android.dialer.callrecord.CallRecording;
 import com.android.dialer.callrecord.ICallRecorderService;
 
@@ -38,22 +41,18 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 
-import com.android.dialer.R;
-
-import static java.lang.Integer.parseInt;
-
 public class CallRecorderService extends Service {
 
   private static final String TAG = "CallRecorderService";
   private static final boolean DBG = false;
 
-  private static final String KEY_CALL_RECORDING_AUDIO_SOURCE = "call_recording_audio_source";
+  static final String KEY_CALL_RECORDING_AUDIO_SOURCE = "call_recording_audio_source";
   private static final String KEY_CALL_RECORDING_OUTPUT_FORMAT = "call_recording_output_format";
 
   private MediaRecorder mMediaRecorder = null;
   private CallRecording mCurrentRecording = null;
 
-  private SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd-HHmmss");
+  static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd-HHmmss");
 
   private final ICallRecorderService.Stub mBinder = new ICallRecorderService.Stub() {
     @Override
@@ -100,12 +99,10 @@ public class CallRecorderService extends Service {
     return parseInt(getPrefs().getString(KEY_CALL_RECORDING_AUDIO_SOURCE, def));
   }
 
-  private static final int OUTPUT_FORMAT_AAC_MPEG_4 = 0;
-  private static final int OUTPUT_FORMAT_AMR_WB = 1;
-
-  private int getOutputFormat() {
+  private OutputFormat getOutputFormat() {
     String def = getString(R.string.call_recording_output_format_default);
-    return parseInt(getPrefs().getString(KEY_CALL_RECORDING_OUTPUT_FORMAT, def));
+    int selectionId = parseInt(getPrefs().getString(KEY_CALL_RECORDING_OUTPUT_FORMAT, def));
+    return OutputFormat.getOutputFormat(selectionId);
   }
 
   private synchronized boolean startRecordingInternal(String phoneNumber, long creationTime) {
@@ -123,17 +120,17 @@ public class CallRecorderService extends Service {
     Log.i(TAG, "Starting recording");
 
     final int audioSource = getAudioSource();
-    final int outputFormat = getOutputFormat();
+    final OutputFormat outputFormat = getOutputFormat();
 
     mMediaRecorder = new MediaRecorder();
     try {
       Log.d(TAG, "Creating media recorder with audio source " + audioSource);
 
       mMediaRecorder.setAudioSource(audioSource);
-      if (outputFormat == OUTPUT_FORMAT_AAC_MPEG_4) {
+      if (outputFormat == OutputFormat.AAC_MPEG_4) {
         mMediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
         mMediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
-      } else if (outputFormat == OUTPUT_FORMAT_AMR_WB){
+      } else if (outputFormat == OutputFormat.AMR_WB) {
         mMediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.AMR_WB);
         mMediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_WB);
       } else {
@@ -210,16 +207,15 @@ public class CallRecorderService extends Service {
     if (DBG) Log.d(TAG, "Destroying CallRecorderService");
   }
 
-  private String generateFilename(String number, int outputFormat) {
+  static String generateFilename(String number, OutputFormat outputFormat) {
     String timestamp = DATE_FORMAT.format(new Date());
-    String extension = (outputFormat == OUTPUT_FORMAT_AAC_MPEG_4) ? ".m4a" : ".amr";
 
     if (TextUtils.isEmpty(number)) {
       number = "unknown";
     }
 
     // CallRecord_yyyyMMdd-HHmmss_numberextension.amr/m4a
-    return "CallRecord_" + timestamp + "_" + number + extension;
+    return "CallRecord_" + timestamp + "_" + number + outputFormat.extension;
   }
 
   private void releaseMediaRecorder() {

--- a/java/com/android/dialer/callrecord/impl/CallRecorderService.java
+++ b/java/com/android/dialer/callrecord/impl/CallRecorderService.java
@@ -41,6 +41,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 
+@Deprecated
 public class CallRecorderService extends Service {
 
   private static final String TAG = "CallRecorderService";

--- a/java/com/android/dialer/callrecord/impl/CallRecorderService.java
+++ b/java/com/android/dialer/callrecord/impl/CallRecorderService.java
@@ -148,6 +148,11 @@ public class CallRecorderService extends Service {
     String fileName = generateFilename(phoneNumber, outputFormat);
     Uri uri = getContentResolver().insert(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
             CallRecording.generateMediaInsertValues(fileName, creationTime));
+    if (uri == null) {
+      Log.e(TAG, "failed to get uri from MediaStore");
+      releaseMediaRecorder();
+      return false;
+    }
 
     try {
       try (ParcelFileDescriptor pfd = getContentResolver().openFileDescriptor(uri, "w")) {

--- a/java/com/android/dialer/callrecord/impl/CallRecorderServiceV2.java
+++ b/java/com/android/dialer/callrecord/impl/CallRecorderServiceV2.java
@@ -121,6 +121,13 @@ public class CallRecorderServiceV2 extends Service {
     String fileName = generateFilename(phoneNumber, outputFormat);
     final Uri uri = getContentResolver().insert(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
             CallRecording.generateMediaInsertValues(fileName, creationTime));
+
+    if (uri == null) {
+      Log.e(TAG, "failed to get uri from MediaStore");
+      mCallRecorder.close();
+      return false;
+    }
+
     try {
       switch (outputFormat) {
         case AAC_MPEG_4: // fall-through
@@ -141,14 +148,14 @@ public class CallRecorderServiceV2 extends Service {
     } catch (IllegalStateException | IllegalArgumentException e) {
       Log.e(TAG, "Could not start recording", e);
       getContentResolver().delete(uri, null, null);
-      stopCallRecorder();
+      stopAndReleaseCallRecorder();
       return false;
     }
   }
 
   private synchronized CallRecording stopRecordingInternal() {
     Log.d(TAG, "stopRecordingInternal");
-    stopCallRecorder();
+    stopAndReleaseCallRecorder();
 
     final CallRecording recording = mCurrentRecording;
     if (recording != null) {
@@ -162,7 +169,7 @@ public class CallRecorderServiceV2 extends Service {
     return recording;
   }
 
-  private void stopCallRecorder() {
+  private void stopAndReleaseCallRecorder() {
     try (BaseCallRecorder recorder = mCallRecorder) {
       if (recorder != null) {
         recorder.stopRecordingBlocking();
@@ -176,6 +183,6 @@ public class CallRecorderServiceV2 extends Service {
   public void onDestroy() {
     super.onDestroy();
     Log.d(TAG, "onDestroy");
-    stopCallRecorder();
+    stopAndReleaseCallRecorder();
   }
 }

--- a/java/com/android/dialer/callrecord/impl/CallRecorderServiceV2.java
+++ b/java/com/android/dialer/callrecord/impl/CallRecorderServiceV2.java
@@ -1,0 +1,181 @@
+package com.android.dialer.callrecord.impl;
+
+import static com.android.dialer.callrecord.impl.CallRecorderService.DATE_FORMAT;
+import static com.android.dialer.callrecord.impl.CallRecorderService.KEY_CALL_RECORDING_AUDIO_SOURCE;
+
+import static java.lang.Integer.parseInt;
+
+import android.Manifest;
+import android.app.Service;
+import android.content.ContentUris;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.provider.MediaStore;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.android.dialer.R;
+import com.android.dialer.callrecord.CallRecording;
+import com.android.dialer.callrecord.ICallRecorderService;
+
+import java.util.Date;
+
+public class CallRecorderServiceV2 extends Service {
+  private static final String TAG = "CallRecorderServiceV2";
+
+  private BaseCallRecorder mCallRecorder;
+
+  private CallRecording mCurrentRecording;
+
+  private final ICallRecorderService.Stub mBinder = new ICallRecorderService.Stub() {
+    @Override
+    public boolean startRecording(String phoneNumber, long creationTime) throws RemoteException {
+      return startRecordingInternal(phoneNumber, creationTime);
+    }
+
+    @Override
+    public CallRecording stopRecording() throws RemoteException {
+      return stopRecordingInternal();
+    }
+
+    @Override
+    public boolean isRecording() throws RemoteException {
+      return mCallRecorder != null && mCallRecorder.isRecording();
+    }
+
+    @Override
+    public CallRecording getActiveRecording() throws RemoteException {
+      return mCurrentRecording;
+    }
+  };
+
+  @Override
+  public IBinder onBind(Intent intent) {
+    Log.d(TAG, "onBind " + intent);
+    return mBinder;
+  }
+
+  private static SharedPreferences getPrefs(Context context) {
+    // This replicates PreferenceManager.getDefaultSharedPreferences, except
+    // that we need multi process preferences, as the pref is written in a separate
+    // process (com.android.dialer vs. com.android.incallui)
+    final String prefName = context.getPackageName() + "_preferences";
+    // TODO: MODE_MULTI_PROCESS is deprecated, but the settings screen relies on preferences still
+    return context.getSharedPreferences(prefName, MODE_MULTI_PROCESS);
+  }
+
+  private SharedPreferences getPrefs() {
+    return getPrefs(this);
+  }
+
+  private int getAudioSource() {
+    String def = getString(R.string.call_recording_audio_source_default);
+    return parseInt(getPrefs().getString(KEY_CALL_RECORDING_AUDIO_SOURCE, def));
+  }
+  private static final String KEY_CALL_RECORDING_OUTPUT_FORMAT = "call_recording_output_format_v2";
+
+  public static boolean isV2Enabled(Context context) {
+    return getPrefs(context).getBoolean("call_recording_use_v2", false);
+  }
+
+  private OutputFormat getOutputFormat() {
+    String def = getString(R.string.call_recording_output_format_default);
+    int selectionId = parseInt(getPrefs().getString(KEY_CALL_RECORDING_OUTPUT_FORMAT, def));
+    return OutputFormat.getOutputFormat(selectionId);
+  }
+
+  static String generateFilename(String number, OutputFormat outputFormat) {
+    String timestamp = DATE_FORMAT.format(new Date());
+
+    if (TextUtils.isEmpty(number)) {
+      number = "unknown";
+    }
+
+    // CallRecord_yyyyMMdd-HHmmss_number.extension (.amr/.m4a/.wav)
+    return "CallRecord_" + timestamp + "_" + number + outputFormat.extension;
+  }
+
+  private synchronized boolean startRecordingInternal(String phoneNumber, long creationTime) {
+    Log.i(TAG, "startRecordingInternal");
+    if (mCallRecorder != null && mCallRecorder.isRecording()) {
+      Log.i(TAG, "Start called with recording in progress, stopping current recording");
+      stopRecordingInternal();
+    }
+
+    if (checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+            != PackageManager.PERMISSION_GRANTED) {
+      Log.e(TAG, "Record audio permission not granted, can't record call");
+      return false;
+    }
+
+    Log.i(TAG, "Starting recording");
+
+    final int audioSource = getAudioSource();
+    final OutputFormat outputFormat = getOutputFormat();
+
+    String fileName = generateFilename(phoneNumber, outputFormat);
+    final Uri uri = getContentResolver().insert(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            CallRecording.generateMediaInsertValues(fileName, creationTime));
+    try {
+      switch (outputFormat) {
+        case AAC_MPEG_4: // fall-through
+        case AMR_WB:
+          mCallRecorder = new MediaCodecRecorder(this, audioSource, uri, outputFormat);
+          break;
+        case LPCM_WAV:
+          mCallRecorder = new WavLPCMRecorder(this, audioSource, uri, outputFormat);
+          break;
+      }
+      mCallRecorder.startRecording();
+
+      long mediaId = Long.parseLong(uri.getLastPathSegment());
+      mCurrentRecording = new CallRecording(phoneNumber, creationTime,
+              fileName, System.currentTimeMillis(), mediaId);
+
+      return true;
+    } catch (IllegalStateException | IllegalArgumentException e) {
+      Log.e(TAG, "Could not start recording", e);
+      getContentResolver().delete(uri, null, null);
+      stopCallRecorder();
+      return false;
+    }
+  }
+
+  private synchronized CallRecording stopRecordingInternal() {
+    Log.d(TAG, "stopRecordingInternal");
+    stopCallRecorder();
+
+    final CallRecording recording = mCurrentRecording;
+    if (recording != null) {
+      Uri uri = ContentUris.withAppendedId(
+              MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, mCurrentRecording.mediaId);
+      getContentResolver().update(uri, CallRecording.generateCompletedValues(), null, null);
+
+      mCurrentRecording = null;
+
+    }
+    return recording;
+  }
+
+  private void stopCallRecorder() {
+    try (BaseCallRecorder recorder = mCallRecorder) {
+      if (recorder != null) {
+        recorder.stopRecordingBlocking();
+      }
+    } finally {
+      mCallRecorder = null;
+    }
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    Log.d(TAG, "onDestroy");
+    stopCallRecorder();
+  }
+}

--- a/java/com/android/dialer/callrecord/impl/CallRecorderServiceV2.java
+++ b/java/com/android/dialer/callrecord/impl/CallRecorderServiceV2.java
@@ -45,7 +45,7 @@ public class CallRecorderServiceV2 extends Service {
 
     @Override
     public boolean isRecording() throws RemoteException {
-      return mCallRecorder != null && mCallRecorder.isRecording();
+      return isRecordingInternal();
     }
 
     @Override
@@ -100,9 +100,14 @@ public class CallRecorderServiceV2 extends Service {
     return "CallRecord_" + timestamp + "_" + number + outputFormat.extension;
   }
 
+  private boolean isRecordingInternal() {
+    final BaseCallRecorder callRecorder = mCallRecorder;
+    return callRecorder != null && callRecorder.isRecording();
+  }
+
   private synchronized boolean startRecordingInternal(String phoneNumber, long creationTime) {
     Log.i(TAG, "startRecordingInternal");
-    if (mCallRecorder != null && mCallRecorder.isRecording()) {
+    if (isRecordingInternal()) {
       Log.i(TAG, "Start called with recording in progress, stopping current recording");
       stopRecordingInternal();
     }

--- a/java/com/android/dialer/callrecord/impl/MediaCodecRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/MediaCodecRecorder.java
@@ -1,0 +1,221 @@
+package com.android.dialer.callrecord.impl;
+
+import android.content.Context;
+import android.media.MediaCodec;
+import android.media.MediaCodecList;
+import android.media.MediaFormat;
+import android.media.MediaMuxer;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+
+/**
+ * Encodes call audio with MediaCodec, then writing to container is done using either MediaMuxer
+ * or written directly (AMR)
+ * <p>
+ * android.media.AudioRecord
+ *  -> PCM data
+ *  -> android.media.MediaCodec
+ *  -> android.media.MediaMuxer or raw OutputStream to write to file
+ * <p>
+ * For simplicity, everything will be handled in one thread. Using asynchronous MediaCodec requires
+ * a Handler, and the MediaCodec code is in a separate thread from the AudioThread code anyway.
+ */
+public class MediaCodecRecorder extends BaseCallRecorder {
+  private static final String TAG = "MediaCodecRecorder";
+
+  private AudioWriter mAudioWriter;
+  protected final MediaCodec mMediaCodec;
+  private final MediaFormat mMediaFormat;
+
+  /**
+   *
+   * @throws IllegalArgumentException
+   * @throws IllegalStateException
+   */
+  public MediaCodecRecorder(Context context, int audioSource, Uri uri, OutputFormat outputFormat) {
+    super(context, audioSource, uri, outputFormat);
+
+    switch (outputFormat) {
+      case AAC_MPEG_4:
+        mMediaFormat = MediaFormat.createAudioFormat(MediaFormat.MIMETYPE_AUDIO_AAC,
+                mAudioFormat.getSampleRate(), mAudioFormat.getChannelCount());
+        break;
+      case AMR_WB:
+        mMediaFormat = MediaFormat.createAudioFormat(MediaFormat.MIMETYPE_AUDIO_AMR_WB,
+                mAudioFormat.getSampleRate(), mAudioFormat.getChannelCount());
+        break;
+      default:
+        throw new IllegalArgumentException("unexpected output format " + outputFormat);
+    }
+    mMediaFormat.setInteger(MediaFormat.KEY_BIT_RATE, outputFormat.bitRate);
+
+    final String encoderForFormat = new MediaCodecList(MediaCodecList.REGULAR_CODECS)
+            .findEncoderForFormat(mMediaFormat);
+    if (encoderForFormat == null) {
+      throw new IllegalArgumentException("invalid format " + outputFormat);
+    }
+    Log.d(TAG, "found encoder " + encoderForFormat + " for format " + outputFormat);
+    try {
+      mMediaCodec = MediaCodec.createByCodecName(encoderForFormat);
+    } catch (IOException | IllegalArgumentException e) {
+      String msg = "failed to create codec for " + encoderForFormat;
+      Log.e(TAG, msg, e);
+      throw new IllegalArgumentException(msg, e);
+    }
+  }
+
+  @Override
+  protected void onRecordingStart(ParcelFileDescriptor pfd) throws IOException {
+    switch (mOutputFormat) {
+      case AAC_MPEG_4:
+        mAudioWriter = new AudioWriter.MediaMuxerWrapper(pfd.getFileDescriptor(),
+                MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4);
+        break;
+      case AMR_WB:
+        mAudioWriter = new AmrAudioWriter(pfd.getFileDescriptor());
+        break;
+      default:
+        throw new IllegalStateException("unknown format " + mOutputFormat);
+    }
+    mMediaCodec.configure(mMediaFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
+    mMediaCodec.start();
+  }
+
+  @Override
+  protected void onPcmBufferRead(int totalRead, int read, byte[] pcmBuffer) throws IOException {
+    int bytesEnqueued = 0;
+    final int totalReadBefore = totalRead - read;
+    while (bytesEnqueued < read) {
+      // From queueInputBuffer documentation:
+      // "The presentation timestamp in microseconds for this buffer. This is normally the media time
+      // at which this buffer should be presented (rendered)."
+      long presentationTimeUs = computePresentationTimeUs(totalReadBefore + bytesEnqueued);
+      int inputBufferIndex = mMediaCodec.dequeueInputBuffer(0);
+      if (inputBufferIndex >= 0) {
+        ByteBuffer inBuf = mMediaCodec.getInputBuffer(inputBufferIndex);
+        if (inBuf != null) {
+          int bytesToQueue = Math.min(inBuf.capacity(), read - bytesEnqueued);
+
+          inBuf.clear();
+          inBuf.put(pcmBuffer, bytesEnqueued, bytesToQueue);
+          inBuf.flip();
+
+          bytesEnqueued += bytesToQueue;
+
+          int offset = 0;
+          int flags = 0;
+          mMediaCodec.queueInputBuffer(inputBufferIndex, offset, bytesToQueue, presentationTimeUs, flags);
+        }
+      } else {
+        Log.d(TAG, " dequeueInputBuffer index is < 0 : " + inputBufferIndex + ", bytesEnqueued " + bytesEnqueued);
+      }
+
+      MediaCodec.BufferInfo info = new MediaCodec.BufferInfo();
+      if (drainEncoder(info, false)) {
+        Log.d(TAG, "drainEncoder eos reached, bytesEnqueued " + bytesEnqueued);
+        break;
+      }
+    }
+  }
+
+  @Override
+  protected void onRecordingStop() throws IOException {
+    Log.d(TAG, "signalling end of stream");
+    int inputBufferIndex = mMediaCodec.dequeueInputBuffer(10000);
+    if (inputBufferIndex >= 0) {
+      mMediaCodec.queueInputBuffer(inputBufferIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+    }
+    MediaCodec.BufferInfo info = new MediaCodec.BufferInfo();
+    drainEncoder(info, true);
+  }
+
+  private boolean drainEncoder(MediaCodec.BufferInfo info, boolean shouldLoopUntilEos)
+          throws IOException {
+    while (!Thread.currentThread().isInterrupted()) {
+      int outputBufferIndex = mMediaCodec.dequeueOutputBuffer(info, 0);
+      if (outputBufferIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+        mAudioWriter.init(mMediaCodec.getOutputFormat());
+      } else if (outputBufferIndex == MediaCodec.INFO_TRY_AGAIN_LATER) {
+        if (!shouldLoopUntilEos) {
+          return false;
+        }
+        // Keep draining until end of stream
+      } else if (outputBufferIndex >= 0) {
+        ByteBuffer outBuf = mMediaCodec.getOutputBuffer(outputBufferIndex);
+        try {
+          if (outBuf == null) {
+            Log.w(TAG, "drainEncoder: unexpected null output buffer");
+            return false;
+          }
+
+          if ((info.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) == 0) {
+            outBuf.position(info.offset);
+            outBuf.limit(info.offset + info.size);
+            mAudioWriter.write(outBuf, info);
+          } else {
+            Log.d(TAG, "drainEncoder: skipping codec config");
+          }
+
+          final boolean isEos = (info.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0;
+
+          if (shouldLoopUntilEos) {
+            if (isEos) {
+              return true;
+            }
+            // Loop
+          } else {
+            // Don't loop. Since input and output buffers are handled in same thread, go back to
+            // exit drainEncoder loop and go back to processing input buffer
+            return isEos;
+          }
+        } finally {
+          mMediaCodec.releaseOutputBuffer(outputBufferIndex, false);
+        }
+      }
+    }
+    return true;
+  }
+
+  private void closeAudioWriter() {
+    final AudioWriter writer = mAudioWriter;
+    if (writer != null) {
+      try {
+        writer.close();
+      } catch (Exception ignored) {
+      }
+      mAudioWriter = null;
+    }
+  }
+
+  @Override
+  protected void reset() {
+    try {
+      mMediaCodec.flush();
+    } catch (IllegalStateException e) {
+      Log.w(TAG, "reset: flush failed", e);
+    }
+    try {
+      mMediaCodec.stop();
+    } catch (IllegalStateException e) {
+      Log.w(TAG, "reset: stop failed", e);
+    }
+    // Documentation says need to configure mMediaCodec again after stop
+    closeAudioWriter();
+  }
+
+  @Override
+  protected void onClose() {
+    closeAudioWriter();
+
+    try {
+      mMediaCodec.stop();
+    } catch (IllegalStateException ignored) {
+    }
+    mMediaCodec.release();
+  }
+}

--- a/java/com/android/dialer/callrecord/impl/MediaCodecRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/MediaCodecRecorder.java
@@ -87,9 +87,9 @@ public class MediaCodecRecorder extends BaseCallRecorder {
   }
 
   @Override
-  protected void onPcmBufferRead(int totalRead, int read, byte[] pcmBuffer) throws IOException {
+  protected void onPcmBufferRead(int read, byte[] pcmBuffer) throws IOException {
     int bytesEnqueued = 0;
-    final int totalReadBefore = totalRead - read;
+    final int totalReadBefore = mBytesRead.get() - read;
     while (bytesEnqueued < read) {
       // From queueInputBuffer documentation:
       // "The presentation timestamp in microseconds for this buffer. This is normally the media time

--- a/java/com/android/dialer/callrecord/impl/MediaCodecRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/MediaCodecRecorder.java
@@ -87,10 +87,11 @@ public class MediaCodecRecorder extends BaseCallRecorder {
   }
 
   @Override
-  protected void onPcmBufferRead(int read, byte[] pcmBuffer) throws IOException {
+  protected void onPcmBufferRead(ByteBuffer pcmBuffer) throws IOException {
     int bytesEnqueued = 0;
-    final int totalReadBefore = mBytesRead.get() - read;
-    while (bytesEnqueued < read) {
+    final int totalReadBefore = mBytesRead.get() - pcmBuffer.limit();
+    pcmBuffer.position(0);
+    while (pcmBuffer.hasRemaining()) {
       // From queueInputBuffer documentation:
       // "The presentation timestamp in microseconds for this buffer. This is normally the media time
       // at which this buffer should be presented (rendered)."
@@ -99,10 +100,15 @@ public class MediaCodecRecorder extends BaseCallRecorder {
       if (inputBufferIndex >= 0) {
         ByteBuffer inBuf = mMediaCodec.getInputBuffer(inputBufferIndex);
         if (inBuf != null) {
-          int bytesToQueue = Math.min(inBuf.capacity(), read - bytesEnqueued);
-
           inBuf.clear();
-          inBuf.put(pcmBuffer, bytesEnqueued, bytesToQueue);
+          // Fill as much as we can into inBuf
+          final int bytesToQueue = Math.min(inBuf.capacity(), pcmBuffer.remaining());
+          // Copy only bytesToQueue from pcmBuffer. ByteBuffer doesnt allow us to put in a certain
+          // number of bytes from a source buffer
+          final int oldLimit = pcmBuffer.limit();
+          pcmBuffer.limit(pcmBuffer.position() + bytesToQueue);
+          inBuf.put(pcmBuffer);
+          pcmBuffer.limit(oldLimit);
           inBuf.flip();
 
           bytesEnqueued += bytesToQueue;
@@ -112,7 +118,8 @@ public class MediaCodecRecorder extends BaseCallRecorder {
           mMediaCodec.queueInputBuffer(inputBufferIndex, offset, bytesToQueue, presentationTimeUs, flags);
         }
       } else {
-        Log.d(TAG, " dequeueInputBuffer index is < 0 : " + inputBufferIndex + ", bytesEnqueued " + bytesEnqueued);
+        Log.d(TAG, " dequeueInputBuffer index is < 0 : " + inputBufferIndex
+                + ", bytesEnqueued " + bytesEnqueued);
       }
 
       MediaCodec.BufferInfo info = new MediaCodec.BufferInfo();

--- a/java/com/android/dialer/callrecord/impl/OutputFormat.java
+++ b/java/com/android/dialer/callrecord/impl/OutputFormat.java
@@ -1,0 +1,55 @@
+package com.android.dialer.callrecord.impl;
+
+import android.media.AudioFormat;
+
+/**
+ * Permitted values for bitrate and sample rate can be found at
+ * https://cs.android.com/android/platform/superproject/main/+/main:frameworks/av/media/libstagefright/data/media_codecs_google_c2_audio.xml
+ * and other .xmls in the directory.
+ * <p>
+ * Note: As of Jan 2026, Google Dialer records with LPCM_WAV with a sample rate of 8000 and then
+ * appears to resample it to 16000. Resampling is done in native code via a "QResampler" (Q31?),
+ * though it converts the PCM data from bytes to floats in Java first (mapping each byte to
+ * the closed interval [-1.0f, 1.0f]). Google Dialer does have MPEG_4 and FLAC implemented via
+ * MediaCodec and MediaMuxer, but it doesn't appear to be used right now.
+ */
+public enum OutputFormat {
+  AAC_MPEG_4(0, AudioFormat.CHANNEL_IN_MONO, 16000, 16000, ".m4a"),
+  /**
+   * Note: A sample rate of 16000 Hz is required for AMR-WB encoders on Android
+   */
+  AMR_WB(1, AudioFormat.CHANNEL_IN_MONO, 16000, 16000, ".amr"),
+  LPCM_WAV(2, AudioFormat.CHANNEL_IN_MONO, 16000, 16000, ".wav");
+
+  public final int selectionIdForPrefs;
+  public final int channelMask;
+  public final int bitRate;
+  public final int sampleRate;
+  public final String extension;
+
+  OutputFormat(int selectionIdForPrefs, int channelMask, int bitRate, int sampleRate,
+          String extension) {
+    this.selectionIdForPrefs = selectionIdForPrefs;
+    this.channelMask = channelMask;
+    this.bitRate = bitRate;
+    this.sampleRate = sampleRate;
+    this.extension = extension;
+  }
+
+  public static OutputFormat getOutputFormat(int selectionIdForPrefs) {
+    if (selectionIdForPrefs < 0 || selectionIdForPrefs >= values().length) {
+      throw new IllegalArgumentException("unexpected output format " + selectionIdForPrefs);
+    }
+    final OutputFormat format = values()[selectionIdForPrefs];
+    if (format.selectionIdForPrefs == selectionIdForPrefs) {
+      return format;
+    }
+    // in case enums are reordered
+    for (OutputFormat fmt : values()) {
+      if (fmt.selectionIdForPrefs == selectionIdForPrefs) {
+        return fmt;
+      }
+    }
+    throw new IllegalArgumentException("unexpected output format " + selectionIdForPrefs);
+  }
+}

--- a/java/com/android/dialer/callrecord/impl/WavLPCMRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/WavLPCMRecorder.java
@@ -31,7 +31,6 @@ import java.nio.charset.StandardCharsets;
 public class WavLPCMRecorder extends BaseCallRecorder {
   private static final String TAG = "WavLPCMRecorder";
   private BufferedOutputStream mOutputStream;
-  private int mBytesWritten;
   private final boolean mShouldUseExtensibleHeader;
   private final int mWavHeaderSize;
   private final int bytesPerSample;
@@ -60,17 +59,17 @@ public class WavLPCMRecorder extends BaseCallRecorder {
   }
 
   @Override
-  protected void onPcmBufferRead(int totalRead, int read, byte[] pcmBuffer) throws IOException {
+  protected void onPcmBufferRead(int read, byte[] pcmBuffer) throws IOException {
     mOutputStream.write(pcmBuffer, 0, read);
-    mBytesWritten += read;
   }
 
   @Override
   protected void onRecordingStop() throws IOException {
     // WAV readers expect samples to be interleaved fully per frame.
     // Trailing partial frames are invalid, so trim to a whole number of frames.
-    final int roundedBytes = mBytesWritten - (mBytesWritten % mAudioFormat.getFrameSizeInBytes());
-    Log.d(TAG, "mBytesWritten " + mBytesWritten + ", roundedBytes " + roundedBytes);
+    final int bytesWritten = mBytesRead.get();
+    final int roundedBytes = bytesWritten - (bytesWritten % mAudioFormat.getFrameSizeInBytes());
+    Log.d(TAG, "mBytesWritten " + bytesWritten + ", roundedBytes " + roundedBytes);
     if (roundedBytes % 2 == 1) {
       Log.d(TAG, "adding empty byte for padding");
       mOutputStream.write(0);
@@ -225,7 +224,6 @@ public class WavLPCMRecorder extends BaseCallRecorder {
 
   @Override
   protected void reset() {
-    mBytesWritten = 0;
     onClose();
   }
 

--- a/java/com/android/dialer/callrecord/impl/WavLPCMRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/WavLPCMRecorder.java
@@ -1,0 +1,243 @@
+package com.android.dialer.callrecord.impl;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.system.ErrnoException;
+import android.system.Os;
+import android.system.OsConstants;
+import android.util.Log;
+
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Writes call audio as uncompressed linear PCM WAV files, i.e. it writes the bytes from AudioRecord
+ * directly with no compression.
+ * <p>
+ * android.media.AudioRecord -> OutputStream
+ * <p>
+ * Note: Google Dialer records using one AudioRecord instance for
+ * {@link android.media.MediaRecorder.AudioSource#VOICE_UPLINK} and another for
+ * {@link android.media.MediaRecorder.AudioSource#VOICE_DOWNLINK}, both in recorded 8000 Hz. Then
+ * both are resampled to 16000 Hz, then two tracks are combined into a 2-channel .WAV file for
+ * export. It's speculated that this design is for AI purposes, e.g. call transcripts being able to
+ * distinguish between caller and callee, plus models being commonly trained on 16000 Hz data.
+ */
+public class WavLPCMRecorder extends BaseCallRecorder {
+  private static final String TAG = "WavLPCMRecorder";
+  private BufferedOutputStream mOutputStream;
+  private int mBytesWritten;
+  private final boolean mShouldUseExtensibleHeader;
+  private final int mWavHeaderSize;
+  private final int bytesPerSample;
+
+  public WavLPCMRecorder(Context context, int audioSource, Uri uri, OutputFormat outputFormat) {
+    super(context, audioSource, uri, outputFormat);
+    if (outputFormat != OutputFormat.LPCM_WAV) {
+      throw new IllegalArgumentException("invalid output format " + outputFormat);
+    }
+    if (mAudioFormat.getChannelCount() == 0) {
+      throw new IllegalArgumentException("zero channel count");
+    }
+    bytesPerSample = mAudioFormat.getFrameSizeInBytes() / mAudioFormat.getChannelCount();
+    // As long as we use ENCODING_PCM_16BIT and CHANNEL_IN_MONO, this will be false.
+    mShouldUseExtensibleHeader = bytesPerSample > 2 || mAudioFormat.getChannelCount() > 2;
+    mWavHeaderSize = mShouldUseExtensibleHeader ? 68 : 44;
+  }
+
+  @Override
+  protected void onRecordingStart(ParcelFileDescriptor pfd) throws IOException {
+    mOutputStream = new BufferedOutputStream(new FileOutputStream(pfd.getFileDescriptor()));
+    // Allocate space for the WAV header. This will be written after recording is done, as the
+    // header requires the data size.
+    byte[] empty = new byte[mWavHeaderSize];
+    mOutputStream.write(empty);
+  }
+
+  @Override
+  protected void onPcmBufferRead(int totalRead, int read, byte[] pcmBuffer) throws IOException {
+    mOutputStream.write(pcmBuffer, 0, read);
+    mBytesWritten += read;
+  }
+
+  @Override
+  protected void onRecordingStop() throws IOException {
+    // WAV readers expect samples to be interleaved fully per frame.
+    // Trailing partial frames are invalid, so trim to a whole number of frames.
+    final int roundedBytes = mBytesWritten - (mBytesWritten % mAudioFormat.getFrameSizeInBytes());
+    Log.d(TAG, "mBytesWritten " + mBytesWritten + ", roundedBytes " + roundedBytes);
+    if (roundedBytes % 2 == 1) {
+      Log.d(TAG, "adding empty byte for padding");
+      mOutputStream.write(0);
+    }
+    mOutputStream.flush();
+    // Close the output stream. We will reopen it in writeWavHeader with a different mode to write
+    // the header to the beginning of the file.
+    onClose();
+
+    writeWavHeader(roundedBytes);
+  }
+
+  private void writeWavHeader(final int roundedWrittenBytes) throws IOException {
+    // Seekable pfd
+    ParcelFileDescriptor pfd = mContentResolver.openFileDescriptor(mUri, "rw");
+    if (pfd == null) {
+      throw new IOException("missing pfd");
+    }
+    try (FileOutputStream fos = new FileOutputStream(pfd.getFileDescriptor())) {
+      try {
+        // FileChannel doesn't appear to work; seek manually
+        if (Os.lseek(pfd.getFileDescriptor(), 0, OsConstants.SEEK_SET) != 0) {
+          throw new IOException("lseek did not move offset to 0");
+        }
+      } catch (ErrnoException e) {
+        throw new IOException("cannot seek pfd", e);
+      }
+      fos.write(getHeaderBytes(roundedWrittenBytes));
+      Log.d(TAG, "wrote WAV header");
+    } finally {
+      pfd.close();
+    }
+  }
+
+  private static final String WAV_HEADER_TAG_RIFF = "RIFF";
+  private static final String WAV_HEADER_TAG_WAVE = "WAVE";
+  private static final String WAV_HEADER_TAG_FORMAT_CHUNK = "fmt ";
+  private static final String WAV_HEADER_TAG_DATA_CHUNK = "data";
+  /** Size of WAVEFORMATEX */
+  private static final int WAV_HEADER_FMT_CHUNK_SIZE = 16;
+  /** Size of extra format information from WAVEFORMATEXTENSIBLE */
+  private static final int WAV_HEADER_EXTRA_FMT_INFO_SIZE = 24;
+
+  private byte[] getHeaderBytes(final int roundedWrittenBytes) {
+    final byte[] header = new byte[mWavHeaderSize];
+    final ByteBuffer headerBuffer = ByteBuffer.wrap(header);
+    headerBuffer.order(ByteOrder.LITTLE_ENDIAN);
+
+    final int fmtChunkSize = mShouldUseExtensibleHeader
+            ? WAV_HEADER_FMT_CHUNK_SIZE + WAV_HEADER_EXTRA_FMT_INFO_SIZE // 40
+            : WAV_HEADER_FMT_CHUNK_SIZE;
+
+    // "RIFF"
+    // [+4 bytes] [total: 4]
+    headerBuffer.put(WAV_HEADER_TAG_RIFF.getBytes(StandardCharsets.US_ASCII));
+    // size (fileSize - 8)
+    // = fmtChunkSize + 20 ("WAVE"(4) + "fmt "(8) + "data"(8))
+    //     + roundedWrittenBytes + (padding: roundedWrittenBytes % 2)
+    // [+4 bytes] [total: 8]
+    headerBuffer.putInt(fmtChunkSize + 20 + roundedWrittenBytes + (roundedWrittenBytes % 2));
+
+    // "WAVE"
+    // [+4 bytes] [total: 12]
+    headerBuffer.put(WAV_HEADER_TAG_WAVE.getBytes(StandardCharsets.US_ASCII));
+
+    // "fmt " chunk header and size
+    // [+8 bytes] [total: 20]
+    headerBuffer.put(WAV_HEADER_TAG_FORMAT_CHUNK.getBytes(StandardCharsets.US_ASCII));
+    headerBuffer.putInt(fmtChunkSize);
+
+    // https://learn.microsoft.com/en-us/windows/win32/api/mmeapi/ns-mmeapi-waveformatex
+
+    // wFormatTag: WAVE_FORMAT_PCM = 1, WAVE_FORMAT_EXTENSIBLE = 0xFFFE
+    // [+2 bytes] [total: 22]
+    headerBuffer.putShort(mShouldUseExtensibleHeader ? (short) 0xFFFE : (short) 0x0001);
+
+    // nChannels
+    // [+2 bytes] [total: 24]
+    headerBuffer.putShort((short) mAudioFormat.getChannelCount());
+
+    // nSamplesPerSec
+    // [+4 bytes] [total: 28]
+    headerBuffer.putInt(mAudioFormat.getSampleRate());
+
+    // nAvgBytesPerSec = sampleRate * channels * bytesPerSample = sampleRate * frameSizeInBytes
+    // [+4 bytes] [total: 32]
+    headerBuffer.putInt(mAudioFormat.getSampleRate() * mAudioFormat.getFrameSizeInBytes());
+
+    // nBlockAlign = channels * bytesPerSample = frameSizeInBytes
+    // [+2 bytes] [total: 34]
+    headerBuffer.putShort((short) (mAudioFormat.getFrameSizeInBytes()));
+
+    // wBitsPerSample
+    // [+2 bytes] [total: 36]
+    headerBuffer.putShort((short) (8 * bytesPerSample));
+
+    if (mShouldUseExtensibleHeader) {
+      // https://learn.microsoft.com/en-us/windows/win32/api/mmreg/ns-mmreg-waveformatextensible
+
+      // cbSize = 22 (from WAVEFORMATEX)
+      // https://learn.microsoft.com/en-us/previous-versions/dd757713(v=vs.85)#members
+      // "Size, in bytes, of extra format information appended to the end of the WAVEFORMATEX
+      // structure."
+      // "For WAVE_FORMAT_PCM formats (and only WAVE_FORMAT_PCM formats), this member is ignored.
+      // When this structure is included in a WAVEFORMATEXTENSIBLE structure, this value must be
+      // at least 22."
+      // [+2 bytes] [extra fmt info total: 2]
+      headerBuffer.putShort((short) 22);
+      // cbSize is not part of extra format information, so it will be 24 - 2 = 22 here
+
+      // wValidBitsPerSample
+      // [+2 bytes] [extra fmt info total: 4]
+      headerBuffer.putShort((short) (8 * bytesPerSample));
+
+      // dwChannelMask (speaker positions). 0 = unspecified.
+      // [+4 bytes] [extra fmt info total: 8]
+      headerBuffer.putInt(0);
+
+      // SubFormat = KSDATAFORMAT_SUBTYPE_PCM
+      // GUID (text): 00000001-0000-0010-8000-00AA00389B71
+      //
+      // Windows GUID binary layout LE for Data1/Data2/Data3; Data4 as-is:
+      // (https://learn.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid)
+      // (https://en.wikipedia.org/wiki/Universally_unique_identifier#Endianness)
+      // [+16 bytes] [extra fmt info total: 24]
+      byte[] KSDATAFORMAT_SUBTYPE_PCM_LE = new byte[] {
+              0x01, 0x00, 0x00, 0x00,       // Data1 = 0x00000001 (LE)
+              0x00, 0x00,                   // Data2 = 0x0000 (LE)
+              0x10, 0x00,                   // Data3 = 0x0010 (LE)
+              (byte) 0x80, 0x00,            // Data4[0..1]
+              0x00, (byte) 0xAA,            // Data4[2..3]
+              0x00, 0x38, (byte) 0x9B, 0x71 // Data4[4..7]
+      };
+      headerBuffer.put(KSDATAFORMAT_SUBTYPE_PCM_LE);
+
+        /*
+        Note: Google Dialer does this equivalent behavior:
+            writeIntegerAsLittleEndianShortToOutputStream(outputStream, 1)
+            byte[] a = {0, 0, 0, 0, 16, 0, Byte.MIN_VALUE, 0, 0, -86, 0, 56, -101, 113};
+            outputStream.write(a);
+        */
+    }
+    // If mShouldUseExtensibleHeader is true, [+24 bytes from WAV_HEADER_EXTRA_FMT_INFO_SIZE]
+
+    // "data" chunk header [+4 bytes] [total: 40]
+    headerBuffer.put(WAV_HEADER_TAG_DATA_CHUNK.getBytes(StandardCharsets.US_ASCII));
+    // data chunk size (payload only; pad byte is not counted here)
+    // [+4 bytes] [total: 44] [mShouldUseExtensibleHeader total: 44+24 = 68]
+    headerBuffer.putInt(roundedWrittenBytes);
+    return header;
+  }
+
+  @Override
+  protected void reset() {
+    mBytesWritten = 0;
+    onClose();
+  }
+
+  @Override
+  protected void onClose() {
+    final BufferedOutputStream outputStream = mOutputStream;
+    if (outputStream != null) {
+      try {
+        outputStream.close();
+      } catch (IOException ignored) {
+      }
+    }
+    mOutputStream = null;
+  }
+}

--- a/java/com/android/dialer/callrecord/impl/WavLPCMRecorder.java
+++ b/java/com/android/dialer/callrecord/impl/WavLPCMRecorder.java
@@ -13,6 +13,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -31,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 public class WavLPCMRecorder extends BaseCallRecorder {
   private static final String TAG = "WavLPCMRecorder";
   private BufferedOutputStream mOutputStream;
+  private WritableByteChannel mOutputStreamChannel;
   private final boolean mShouldUseExtensibleHeader;
   private final int mWavHeaderSize;
   private final int bytesPerSample;
@@ -52,6 +55,7 @@ public class WavLPCMRecorder extends BaseCallRecorder {
   @Override
   protected void onRecordingStart(ParcelFileDescriptor pfd) throws IOException {
     mOutputStream = new BufferedOutputStream(new FileOutputStream(pfd.getFileDescriptor()));
+    mOutputStreamChannel = Channels.newChannel(mOutputStream);
     // Allocate space for the WAV header. This will be written after recording is done, as the
     // header requires the data size.
     byte[] empty = new byte[mWavHeaderSize];
@@ -59,8 +63,8 @@ public class WavLPCMRecorder extends BaseCallRecorder {
   }
 
   @Override
-  protected void onPcmBufferRead(int read, byte[] pcmBuffer) throws IOException {
-    mOutputStream.write(pcmBuffer, 0, read);
+  protected void onPcmBufferRead(ByteBuffer pcmBuffer) throws IOException {
+    mOutputStreamChannel.write(pcmBuffer);
   }
 
   @Override

--- a/java/com/android/incallui/call/CallRecorder.java
+++ b/java/com/android/incallui/call/CallRecorder.java
@@ -34,6 +34,7 @@ import com.android.dialer.R;
 import com.android.dialer.callrecord.CallRecording;
 import com.android.dialer.callrecord.ICallRecorderService;
 import com.android.dialer.callrecord.impl.CallRecorderService;
+import com.android.dialer.callrecord.impl.CallRecorderServiceV2;
 import com.android.dialer.location.GeoUtil;
 import com.android.incallui.call.state.DialerCallState;
 
@@ -99,7 +100,10 @@ public class CallRecorder implements CallList.Listener {
 
   private void initialize() {
     if (!initialized) {
-      Intent serviceIntent = new Intent(context, CallRecorderService.class);
+      final boolean v2Enabled = CallRecorderServiceV2.isV2Enabled(context);
+      Log.d(TAG, "Using Call Recording V2: " + v2Enabled);
+      Intent serviceIntent = new Intent(context, v2Enabled ? CallRecorderServiceV2.class
+              : CallRecorderService.class);
       context.bindService(serviceIntent, connection, Context.BIND_AUTO_CREATE);
       initialized = true;
     }


### PR DESCRIPTION
See https://github.com/GrapheneOS/os-issue-tracker/issues/5145. A user on the forum has recently reported still having call recording issues (https://discuss.grapheneos.org/d/24368-call-recording-causing-audio-service-crashes-and-call-interruptions/51), although no logs have been provided.

This adds new call recording code using the same framework APIs as Google Dialer (`android.media`'s
`AudioRecord`, `MediaCodec`, and `MediaMuxer`). By using the same framework APIs as Google Dialer,
we can reap some of the upstream maintenance benefits if they also run into upstream bugs. There's
also some (unconfirmed) evidence that stock dialer call recording has better functionality, e.g. https://github.com/GrapheneOS/os-issue-tracker/issues/6099 mentions stock dialer has handover support going from 3G to LTE to Wi-Fi, so perhaps using same APIs will help with those issues as well.

Uncompressed WAV recording in linear PCM format is also implemented as a new output option; this is
what Google Dialer uses for call recording as of Jan 2026 including exporting call audio out of the
Google Dialer app.

Note that Google Dialer records calls by using two simultaneous `AudioRecord` instances recording in
mono at 8000 Hz. One instance is for `VOICE_UPLINK` and the other is for `VOICE_DOWNLINK`, and both
are later resampled to 16000 Hz. For exporting the call recordings, these WAV files are combined
into a stereo WAV file with a channel for `VOICE_UPLINK` and a channel for `VOICE_DOWNLINK`. It's
speculated that this is also being done for AI purposes like the call transcripts feature. Splitting
the input and output audio streams would make it easier for speech models to work with, and it seems
most speech models are trained on 16000 Hz data. Our implementation currently uses the old options
of `VOICE_CALL` and `VOICE_MIC`, since we don't have a need to split the two channels at the moment.

This is implemented as an opt-in for now so that it can be beta tested.

Output of WAV file with `shntool`:

```
$ shntool info -H CallRecord_test.wav 
-------------------------------------------------------------------------------
File name:                    CallRecord_test.wav
Handled by:                   wav format module
Length:                       38:27.492
WAVE format:                  0x0001 (Microsoft PCM)
Channels:                     1
Bits/sample:                  16
Samples/sec:                  16000
Average bytes/sec:            32000
Rate (calculated):            32000
Block align:                  2
Header size:                  44 bytes
Data size:                    73839756 bytes
Chunk size:                   73839792 bytes
Total size (chunk size + 8):  73839800 bytes
Actual file size:             73839800
File is compressed:           no
Compression ratio:            1.0000
CD-quality properties:
  CD quality:                 no
  Cut on sector boundary:     n/a
  Sector misalignment:        n/a
  Long enough to be burned:   n/a
WAVE properties:
  Non-canonical header:       no
  Extra RIFF chunks:          no
Possible problems:
  File contains ID3v2 tag:    no
  Data chunk block-aligned:   yes
  Inconsistent header:        no
  File probably truncated:    no
  Junk appended to file:      no
  Odd data size has pad byte: n/a
```