### PR TITLE
Update values-ru/strings.xml: fix regression for app name localization

### DIFF
--- a/java/com/android/dialer/main/impl/res/values-ru/strings.xml
+++ b/java/com/android/dialer/main/impl/res/values-ru/strings.xml
@@ -17,7 +17,7 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="main_activity_label" msgid="3121599977875141886">"Позвонить"</string>
+    <string name="main_activity_label" msgid="3121599977875141886">"Телефон"</string>
     <string name="nui_shortcut_name" msgid="6370942901789984087">"Позвонить в новом интерфейсе"</string>
     <string name="main_call_history_tab_description" msgid="1705569872650796265">"Журнал звонков"</string>
     <string name="search" msgid="3570654445331155513">"@android:string/search_go"</string>


### PR DESCRIPTION
In Android 17, 'main_activity_label' is used for application shortcut in launcher, so choosing Russian as interface language makes Dialer app named 'Позвонить' and not 'Телефон' as it should be (such regression is not presented for Bulgarian, Ukranian, Serbian, Macedonian, Kyrgyz and Kazakh localizations)

<details>
<summary>Example of wrong naming of Dialer in Russian</summary>
<img width="894" height="2244" alt="photo_2026-08-22_10-37-10" src="https://github.com/user-attachments/assets/f584b29d-7ccd-4b73-ad6d-e75b087873ed" />
</details>

<details>
<summary>Example of right naming of Dialer in Kazakh</summary>
<img width="947" height="2244" alt="photo_2026-08-22_10-55-18" src="https://github.com/user-attachments/assets/854ceaa5-57a0-4880-8772-c7f3893e4dba" />
</details>