### PR TITLE
callrec: add auto-record all contacts option

### DIFF
--- a/java/com/android/dialer/app/res/values/strings_ext.xml
+++ b/java/com/android/dialer/app/res/values/strings_ext.xml
@@ -65,7 +65,28 @@
     <string name="call_recording_auto_record_category_title">Automatic call recording</string>
     <string name="call_recording_auto_record_direct_boot_notice">After your device restarts, automatic call recording is unavailable until the first unlock.</string>
     <string name="call_recording_auto_record_non_contacts_title">Automatically record calls with non-contacts</string>
-    <string name="call_recording_auto_record_selected_numbers_title">Automatically record these numbers</string>
+    <string name="call_recording_auto_record_selected_numbers_title">Automatically record calls with contacts</string>
+    <string name="call_recording_contact_mode_title">Contacts to record</string>
+    <string name="call_recording_contact_mode_selected">Record only selected numbers</string>
+    <string name="call_recording_contact_mode_all">Record all contacts except selected numbers</string>
+    <string-array name="call_recording_contact_mode_entries">
+        <item>@string/call_recording_contact_mode_selected</item>
+        <item>@string/call_recording_contact_mode_all</item>
+    </string-array>
+    <string name="call_recording_numbers_to_record">Numbers to record</string>
+    <string name="call_recording_numbers_to_exclude">Numbers to exclude</string>
+    <string name="call_recording_all_contacts_empty">All contacts will be recorded when enabled. No numbers excluded.</string>
+    <string name="call_recording_all_contacts_summary">All contacts</string>
+    <plurals name="call_recording_excluded_numbers_count">
+        <item quantity="one">All contacts except 1 number</item>
+        <item quantity="other">All contacts except %d numbers</item>
+    </plurals>
+    <string name="call_recording_change_mode_title">Discard saved numbers and switch?</string>
+    <string name="call_recording_change_mode_to_all_message">Your selected recording numbers will be cleared. All contacts will be recorded when contact recording is enabled, unless you add exceptions. This does not delete contacts from your address book.</string>
+    <string name="call_recording_change_mode_to_selected_message">Your excluded numbers will be cleared. No contacts will be recorded until you select numbers to record. This does not delete contacts from your address book.</string>
+    <string name="call_recording_discard_and_switch">Discard and switch</string>
+    <string name="call_recording_change_mode_failed">Couldn\'t change recording mode. Review the current numbers and try again.</string>
+    <string name="call_recording_remove_exception_message">Calls with this number will be recorded automatically when it belongs to a contact and contact recording is enabled.</string>
     <string name="call_recording_auto_record_selected_numbers_add">Add number</string>
     <string name="call_recording_auto_record_selected_numbers_off">Off</string>
     <string name="call_recording_auto_record_selected_numbers_empty">No numbers selected</string>

--- a/java/com/android/dialer/app/settings/AutoCallRecordingSelectedNumbersFragment.kt
+++ b/java/com/android/dialer/app/settings/AutoCallRecordingSelectedNumbersFragment.kt
@@ -10,7 +10,9 @@ import android.content.Intent
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
+import android.preference.ListPreference
 import android.preference.Preference
+import android.preference.PreferenceCategory
 import android.preference.PreferenceFragment
 import android.preference.PreferenceScreen
 import android.preference.SwitchPreference
@@ -22,7 +24,7 @@ import com.android.dialer.callrecord.AutoCallRecordingContactResolver.ResolvedSe
 import com.android.dialer.callrecord.CallRecordingPermissionHelper
 import com.android.dialer.callrecord.CallRecordingPreferenceValues
 import com.android.dialer.callrecord.CallRecordingPreferencesStore
-import com.android.dialer.callrecord.CallRecordingWarningHelper
+import com.android.dialer.callrecord.ContactRecordingMode
 import com.android.dialer.common.LogUtil
 import com.android.dialer.common.concurrent.DialerExecutorComponent
 import com.android.dialer.phonenumberutil.PhoneNumberCanonicalizer
@@ -37,7 +39,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-/** Settings screen for selected contact numbers that should be recorded automatically. */
+/** Settings screen for contact recording and its included or excluded numbers. */
 class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
 
   private lateinit var appContext: Context
@@ -48,9 +50,14 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
   private lateinit var autoRecordingEnableFlow: AutoCallRecordingEnableFlow
   private var refreshJob: Job? = null
   private var lastRefreshResult: RefreshResult? = null
+  private var pickerMode: ContactRecordingMode? = null
+  private var modeDialog: AlertDialog? = null
+  private var changingMode = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    pickerMode =
+        savedInstanceState?.getString(STATE_PICKER_MODE)?.let { ContactRecordingMode.valueOf(it) }
     val context = activity ?: return
     val executorComponent = DialerExecutorComponent.get(context)
     fragmentScope =
@@ -85,16 +92,24 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
   }
 
   override fun onDestroy() {
+    modeDialog?.dismiss()
     if (::fragmentScope.isInitialized) {
       fragmentScope.cancel()
     }
     super.onDestroy()
   }
 
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    pickerMode?.let { outState.putString(STATE_PICKER_MODE, it.name) }
+  }
+
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     if (requestCode == REQUEST_PICK_AUTO_RECORD_NUMBER) {
-      if (resultCode == Activity.RESULT_OK) {
-        data?.data?.let { addSelectedNumber(it) }
+      val expectedMode = pickerMode
+      pickerMode = null
+      if (resultCode == Activity.RESULT_OK && expectedMode != null) {
+        data?.data?.let { addSelectedNumber(it, expectedMode) }
       }
       return
     }
@@ -122,10 +137,7 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
     refreshJob = fragmentScope.launch {
       try {
         val result = withContext(backgroundDispatcher) { loadSelectedNumbers(appContext) }
-        render(
-            result.selectedNumbers,
-            result.selectedNumbersEnabled,
-            result.recordingWarningPresented)
+        render(result)
       } catch (e: CancellationException) {
         throw e
       } catch (e: Exception) {
@@ -138,13 +150,15 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
     }
   }
 
-  private fun addSelectedNumber(uri: Uri) {
+  private fun addSelectedNumber(uri: Uri, expectedMode: ContactRecordingMode) {
     if (!::appContext.isInitialized || !::fragmentScope.isInitialized) {
       return
     }
     fragmentScope.launch {
       try {
-        val status = withContext(backgroundDispatcher) { addSelectedNumber(appContext, uri) }
+        val status = withContext(backgroundDispatcher) {
+          addSelectedNumber(appContext, uri, expectedMode)
+        }
         onAddNumberComplete(status)
       } catch (e: CancellationException) {
         throw e
@@ -165,24 +179,19 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
         AutoCallRecordingContactResolver.resolveSelectedNumbersAsync(context, selectedNumbers)
     return RefreshResult(
         getDisplayNumbers(selectedNumbers, resolveResult.resolvedNumbers),
-        preferences.autoRecordSelectedNumbersEnabled,
-        preferences.recordingWarningPresented)
+        preferences.autoRecordContactsEnabled,
+        preferences.recordingWarningPresented,
+        preferences.contactRecordingMode)
   }
 
   private fun renderStoredNumbersWithoutCleanup() {
-    lastRefreshResult?.let {
-      render(it.selectedNumbers, it.selectedNumbersEnabled, it.recordingWarningPresented)
-    }
+    lastRefreshResult?.let(::render)
   }
 
-  private fun render(
-      selectedNumbers: List<ResolvedSelectedNumber>,
-      selectedNumbersEnabled: Boolean,
-      recordingWarningPresented: Boolean
-  ) {
+  private fun render(result: RefreshResult) {
     val context = activity ?: return
-    lastRefreshResult =
-        RefreshResult(selectedNumbers, selectedNumbersEnabled, recordingWarningPresented)
+    lastRefreshResult = result
+    val (selectedNumbers, selectedNumbersEnabled, _, mode) = result
     preferenceRoot.removeAll()
 
     enabledPreference =
@@ -196,7 +205,7 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
               refreshAfterPreferenceWrite(
                   "AutoCallRecordingSelectedNumbersFragment.disableSelectedNumbers") {
                     CallRecordingPreferencesStore.update(appContext) {
-                      it.setAutoRecordSelectedNumbersEnabled(false)
+                      it.setAutoRecordContactsEnabled(false)
                           .setAutoRecordingSetAtLeastOnce(true)
                     }
                   }
@@ -206,7 +215,7 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
               refreshAfterPreferenceWrite(
                   "AutoCallRecordingSelectedNumbersFragment.enableSelectedNumbers") {
                     CallRecordingPreferencesStore.update(appContext) {
-                      it.setAutoRecordSelectedNumbersEnabled(true)
+                      it.setAutoRecordContactsEnabled(true)
                           .setAutoRecordingSetAtLeastOnce(true)
                     }
                   }
@@ -217,12 +226,52 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
         }
     preferenceRoot.addPreference(enabledPreference)
 
+    val excludesNumbers = mode == ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS
+    preferenceRoot.addPreference(
+        ListPreference(context).apply {
+          key = "call_recording_contact_mode"
+          setTitle(R.string.call_recording_contact_mode_title)
+          setEntries(R.array.call_recording_contact_mode_entries)
+          entryValues = arrayOf(
+              ContactRecordingMode.SELECTED_NUMBERS.name,
+              ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS.name)
+          isPersistent = false
+          value = mode.name
+          summary = entry
+          setOnPreferenceChangeListener { _, newValue ->
+            requestModeChange(ContactRecordingMode.valueOf(newValue as String))
+            false
+          }
+        })
+
+    preferenceRoot.addPreference(
+        PreferenceCategory(context).apply {
+          setTitle(
+              if (excludesNumbers) {
+                R.string.call_recording_numbers_to_exclude
+              } else {
+                R.string.call_recording_numbers_to_record
+              })
+        })
+    if (selectedNumbers.isEmpty()) {
+      preferenceRoot.addPreference(
+          Preference(context).apply {
+            isSelectable = false
+            setSummary(
+                if (excludesNumbers) {
+                  R.string.call_recording_all_contacts_empty
+                } else {
+                  R.string.call_recording_auto_record_selected_numbers_empty
+                })
+          })
+    }
+
     preferenceRoot.addPreference(
         Preference(context).apply {
           setTitle(R.string.call_recording_auto_record_selected_numbers_add)
           isEnabled = selectedNumbersEnabled
           setOnPreferenceClickListener {
-            launchContactNumberPicker()
+            launchContactNumberPicker(mode)
             true
           }
         })
@@ -235,32 +284,93 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
             display.summary?.let { summary = it }
             isEnabled = selectedNumbersEnabled
             setOnPreferenceClickListener {
-              showRemoveConfirmation(selectedNumber.canonicalNumber)
+              showRemoveConfirmation(selectedNumber.canonicalNumber, mode)
               true
             }
           })
     }
+    preferenceRoot.isEnabled = !changingMode
   }
 
-  private fun launchContactNumberPicker() {
+  private fun requestModeChange(mode: ContactRecordingMode) {
+    val current = lastRefreshResult ?: return
+    if (mode == current.mode || changingMode || modeDialog != null) {
+      return
+    }
+    if (current.selectedNumbers.isEmpty()) {
+      changeMode(current, mode)
+      return
+    }
+    val context = activity ?: return
+    modeDialog = AlertDialog.Builder(context)
+        .setTitle(R.string.call_recording_change_mode_title)
+        .setMessage(
+            if (mode == ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS) {
+              R.string.call_recording_change_mode_to_all_message
+            } else {
+              R.string.call_recording_change_mode_to_selected_message
+            })
+        .setPositiveButton(R.string.call_recording_discard_and_switch) { _, _ ->
+          changeMode(current, mode)
+        }
+        .setNegativeButton(android.R.string.cancel, null)
+        .create().also { dialog ->
+          dialog.setOnDismissListener { modeDialog = null }
+          dialog.show()
+        }
+  }
+
+  private fun changeMode(current: RefreshResult, mode: ContactRecordingMode) {
+    changingMode = true
+    preferenceRoot.isEnabled = false
+    refreshAfterPreferenceWrite(
+        "AutoCallRecordingSelectedNumbersFragment.changeMode",
+        onFailure = {
+          changingMode = false
+          activity?.let { context ->
+            Toast.makeText(context, R.string.call_recording_change_mode_failed, Toast.LENGTH_SHORT)
+                .show()
+          }
+          refreshSelectedNumbers()
+        },
+        onSuccess = {
+          changingMode = false
+          refreshSelectedNumbers()
+        }) {
+          CallRecordingPreferencesStore.update(appContext) {
+            CallRecordingPreferenceValues.switchContactRecordingMode(
+                it, current.mode, current.selectedNumbers.map { it.canonicalNumber }.toSet(), mode)
+          }
+        }
+  }
+
+  private fun launchContactNumberPicker(mode: ContactRecordingMode) {
+    pickerMode = mode
     try {
       startActivityForResult(
           Intent(Intent.ACTION_PICK, Phone.CONTENT_URI), REQUEST_PICK_AUTO_RECORD_NUMBER)
     } catch (e: RuntimeException) {
+      pickerMode = null
       showAddFailed()
     }
   }
 
-  private fun showRemoveConfirmation(canonicalNumber: String) {
+  private fun showRemoveConfirmation(canonicalNumber: String, mode: ContactRecordingMode) {
     val activity = activity ?: return
     AlertDialog.Builder(activity)
         .setTitle(R.string.call_recording_auto_record_remove_number_title)
-        .setMessage(R.string.call_recording_auto_record_remove_number_message)
+        .setMessage(
+            if (mode == ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS) {
+              R.string.call_recording_remove_exception_message
+            } else {
+              R.string.call_recording_auto_record_remove_number_message
+            })
         .setPositiveButton(android.R.string.ok) { _, _ ->
           refreshAfterPreferenceWrite(
               "AutoCallRecordingSelectedNumbersFragment.removeSelectedNumber") {
                 withContext(backgroundDispatcher) {
                   CallRecordingPreferencesStore.update(appContext) {
+                    check(it.contactRecordingMode == mode) { "Contact recording mode changed" }
                     val numbers =
                         CallRecordingPreferenceValues.selectedNumbers(it.build()).toMutableSet()
                     numbers.remove(canonicalNumber)
@@ -337,12 +447,16 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
     CallRecordingPermissionHelper.openAppSettings(context)
   }
 
-  private suspend fun addSelectedNumber(context: Context, uri: Uri): AddNumberStatus {
+  private suspend fun addSelectedNumber(
+      context: Context,
+      uri: Uri,
+      expectedMode: ContactRecordingMode
+  ): AddNumberStatus {
     val canonicalNumber = readPickedCanonicalNumber(context, uri)
     if (canonicalNumber.isNullOrEmpty()) {
       return AddNumberStatus.FAILED
     }
-    return when (SelectedNumberPreferenceUpdater.add(context, canonicalNumber)) {
+    return when (SelectedNumberPreferenceUpdater.add(context, canonicalNumber, expectedMode)) {
       SelectedNumberPreferenceUpdater.AddResult.FAILED -> AddNumberStatus.FAILED
       SelectedNumberPreferenceUpdater.AddResult.ADDED -> AddNumberStatus.ADDED
       SelectedNumberPreferenceUpdater.AddResult.ALREADY_ADDED -> AddNumberStatus.ALREADY_ADDED
@@ -374,7 +488,8 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
   private data class RefreshResult(
       val selectedNumbers: List<ResolvedSelectedNumber>,
       val selectedNumbersEnabled: Boolean,
-      val recordingWarningPresented: Boolean
+      val recordingWarningPresented: Boolean,
+      val mode: ContactRecordingMode
   )
 
   private data class PreferenceDisplay(val title: CharSequence, val summary: String?)
@@ -386,6 +501,7 @@ class AutoCallRecordingSelectedNumbersFragment : PreferenceFragment() {
   }
 
   private companion object {
+    private const val STATE_PICKER_MODE = "picker_mode"
     private const val REQUEST_PICK_AUTO_RECORD_NUMBER = 1
     private const val REQUEST_CODE_AUTO_RECORD_PERMISSION = 1002
     private const val PHONE_NUMBER_INDEX = 0

--- a/java/com/android/dialer/app/settings/CallRecordingSettingsFragment.kt
+++ b/java/com/android/dialer/app/settings/CallRecordingSettingsFragment.kt
@@ -17,6 +17,7 @@ import com.android.dialer.callrecord.CallRecordingPermissionHelper
 import com.android.dialer.callrecord.CallRecordingPreferences
 import com.android.dialer.callrecord.CallRecordingPreferencesStore
 import com.android.dialer.callrecord.CallRecordingWarningHelper
+import com.android.dialer.callrecord.ContactRecordingMode
 import com.android.dialer.callrecord.RecordingOutputFormat
 import com.android.dialer.common.concurrent.DialerExecutorComponent
 import com.android.dialer.util.PermissionsUtil
@@ -319,11 +320,20 @@ class CallRecordingSettingsFragment : PreferenceFragment() {
 
   private fun updateAutomaticRecordingPreferences(preferences: CallRecordingPreferences) {
     updateAutomaticRecordingPermissionWarning(preferences)
-    if (!preferences.autoRecordSelectedNumbersEnabled) {
+    if (!preferences.autoRecordContactsEnabled) {
       autoRecordSelectedNumbers.setSummary(R.string.call_recording_auto_record_selected_numbers_off)
       return
     }
     val count = preferences.autoRecordSelectedNumbersCount
+    if (preferences.contactRecordingMode == ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS) {
+      autoRecordSelectedNumbers.summary =
+          if (count == 0) {
+            getString(R.string.call_recording_all_contacts_summary)
+          } else {
+            resources.getQuantityString(R.plurals.call_recording_excluded_numbers_count, count, count)
+          }
+      return
+    }
     if (count == 0) {
       autoRecordSelectedNumbers.setSummary(
           R.string.call_recording_auto_record_selected_numbers_empty)
@@ -339,7 +349,7 @@ class CallRecordingSettingsFragment : PreferenceFragment() {
     val hasMicrophonePermission = hasMicrophonePermission()
     val hasContactsPermission = hasContactsPermission()
     val showWarning =
-        (preferences.autoRecordNonContacts || preferences.autoRecordSelectedNumbersEnabled) &&
+        (preferences.autoRecordNonContacts || preferences.autoRecordContactsEnabled) &&
             (!hasMicrophonePermission || !hasContactsPermission)
     val isShown = autoRecordCategory.findPreference(autoRecordPermissionWarning.key) != null
     if (showWarning) {

--- a/java/com/android/dialer/app/settings/SelectedNumberPreferenceUpdater.kt
+++ b/java/com/android/dialer/app/settings/SelectedNumberPreferenceUpdater.kt
@@ -3,6 +3,7 @@ package com.android.dialer.app.settings
 import android.content.Context
 import com.android.dialer.callrecord.CallRecordingPreferenceValues
 import com.android.dialer.callrecord.CallRecordingPreferencesStore
+import com.android.dialer.callrecord.ContactRecordingMode
 
 internal object SelectedNumberPreferenceUpdater {
   enum class AddResult {
@@ -11,9 +12,16 @@ internal object SelectedNumberPreferenceUpdater {
     ALREADY_ADDED
   }
 
-  suspend fun add(context: Context, canonicalNumber: String): AddResult {
+  suspend fun add(
+      context: Context,
+      canonicalNumber: String,
+      expectedMode: ContactRecordingMode
+  ): AddResult {
     return CallRecordingPreferencesStore.updateWithResult(
         context, AddResult.FAILED) { preferences ->
+      if (preferences.contactRecordingMode != expectedMode) {
+        return@updateWithResult preferences to AddResult.FAILED
+      }
       val update = CallRecordingPreferenceValues.addSelectedNumber(preferences, canonicalNumber)
       update.first to when (update.second) {
         CallRecordingPreferenceValues.SelectedNumberAddResult.ADDED -> AddResult.ADDED

--- a/java/com/android/dialer/callrecord/AutoCallRecordingStaleContactCleaner.kt
+++ b/java/com/android/dialer/callrecord/AutoCallRecordingStaleContactCleaner.kt
@@ -15,8 +15,9 @@ object AutoCallRecordingStaleContactCleaner {
   suspend fun clean(context: Context, selectedNumberResolver: SelectedNumberResolver): Result {
     val preferences = CallRecordingPreferencesStore.load(context)
     val selectedNumbers = CallRecordingPreferenceValues.selectedNumbers(preferences)
-    val selectedNumberRecordingEnabled = preferences.autoRecordSelectedNumbersEnabled
-    if (!selectedNumberRecordingEnabled || selectedNumbers.isEmpty()) {
+    val selectedNumberRecordingEnabled = preferences.autoRecordContactsEnabled
+    if (!selectedNumberRecordingEnabled || selectedNumbers.isEmpty() ||
+        preferences.contactRecordingMode != ContactRecordingMode.SELECTED_NUMBERS) {
       LogUtil.i(
           "AutoCallRecordingStaleContactCleaner.clean",
           "skipping stale contact cleanup; selectedEnabled=%b, selectedCount=%d",
@@ -56,10 +57,19 @@ object AutoCallRecordingStaleContactCleaner {
       return Result.unchanged(selectedNumbers.size)
     }
 
-    CallRecordingPreferencesStore.update(context) { builder ->
+    val updated = CallRecordingPreferencesStore.update(context) { builder ->
+      // A mode switch may have occurred while resolving contacts. Never prune exceptions.
+      if (!builder.autoRecordContactsEnabled ||
+          builder.contactRecordingMode != ContactRecordingMode.SELECTED_NUMBERS) {
+        return@update
+      }
       val currentSelectedNumbers = builder.autoRecordSelectedNumbersList.toMutableSet()
       currentSelectedNumbers.removeAll(staleNumbers)
       CallRecordingPreferenceValues.setSelectedNumbers(builder, currentSelectedNumbers)
+    }
+    if (!updated.autoRecordContactsEnabled ||
+        updated.contactRecordingMode != ContactRecordingMode.SELECTED_NUMBERS) {
+      return Result.unchanged(selectedNumbers.size)
     }
     LogUtil.i(
         "AutoCallRecordingStaleContactCleaner.clean",

--- a/java/com/android/dialer/callrecord/AutoCallRecordingStaleContactCleanupJobService.kt
+++ b/java/com/android/dialer/callrecord/AutoCallRecordingStaleContactCleanupJobService.kt
@@ -140,8 +140,9 @@ class AutoCallRecordingStaleContactCleanupJobService : JobService() {
     @VisibleForTesting
     @JvmStatic
     fun shouldScheduleCleanup(preferences: CallRecordingPreferences): Boolean {
-      // Only selected number recording depends on contact lookup state.
-      return preferences.autoRecordSelectedNumbersEnabled &&
+      // Keep exceptions even when a contact temporarily disappears.
+      return preferences.autoRecordContactsEnabled &&
+          preferences.contactRecordingMode == ContactRecordingMode.SELECTED_NUMBERS &&
           preferences.autoRecordSelectedNumbersCount > 0
     }
 

--- a/java/com/android/dialer/callrecord/CallRecordingPreferenceValues.kt
+++ b/java/com/android/dialer/callrecord/CallRecordingPreferenceValues.kt
@@ -61,8 +61,42 @@ object CallRecordingPreferenceValues {
   }
 
   @JvmStatic
+  fun shouldRecordContactNumber(
+      preferences: CallRecordingPreferences,
+      canonicalNumber: String?
+  ): Boolean {
+    if (!preferences.autoRecordContactsEnabled || canonicalNumber.isNullOrEmpty()) {
+      return false
+    }
+    val selected = containsSelectedNumber(preferences, canonicalNumber)
+    return when (preferences.contactRecordingMode) {
+      ContactRecordingMode.SELECTED_NUMBERS -> selected
+      ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS -> !selected
+      else -> false
+    }
+  }
+
+  /** Reject stale UI choices rather than discarding numbers the user has not confirmed. */
+  fun switchContactRecordingMode(
+      builder: CallRecordingPreferences.Builder,
+      expectedMode: ContactRecordingMode,
+      expectedNumbers: Set<String>,
+      mode: ContactRecordingMode
+  ) {
+    check(builder.contactRecordingMode == expectedMode &&
+        builder.autoRecordSelectedNumbersList.toSet() == expectedNumbers) {
+      "Contact recording settings changed while choosing a mode"
+    }
+    if (mode != expectedMode) {
+      builder.setContactRecordingMode(mode)
+          .clearAutoRecordSelectedNumbers()
+          .setAutoRecordingSetAtLeastOnce(true)
+    }
+  }
+
+  @JvmStatic
   fun isAnyAutoRecordingSettingEnabled(preferences: CallRecordingPreferences): Boolean {
-    return preferences.autoRecordNonContacts || preferences.autoRecordSelectedNumbersEnabled
+    return preferences.autoRecordNonContacts || preferences.autoRecordContactsEnabled
   }
 
   @JvmStatic

--- a/java/com/android/dialer/callrecord/call_recording_preferences.proto
+++ b/java/com/android/dialer/callrecord/call_recording_preferences.proto
@@ -11,6 +11,11 @@ enum RecordingOutputFormat {
   LPCM_WAV = 2;
 }
 
+enum ContactRecordingMode {
+  SELECTED_NUMBERS = 0;
+  ALL_EXCEPT_SELECTED_NUMBERS = 1;
+}
+
 message CallRecordingPreferences {
   optional bool use_call_recording_v2 = 1 [default = false];
   optional string call_recording_audio_source = 2;
@@ -22,8 +27,11 @@ message CallRecordingPreferences {
   // when there is a second durable migration to distinguish.
   optional bool shared_preferences_migrated = 5 [default = false];
   optional bool auto_record_non_contacts = 6 [default = false];
-  optional bool auto_record_selected_numbers_enabled = 7 [default = false];
+  // Enables contact recording in either contact_recording_mode.
+  optional bool auto_record_contacts_enabled = 7 [default = false];
+  // Numbers to record in SELECTED_NUMBERS mode, or exclude in ALL_EXCEPT_SELECTED_NUMBERS mode.
   repeated string auto_record_selected_numbers = 8;
   optional bool auto_recording_set_at_least_once = 9 [default = false];
   optional bool recording_warning_presented = 10 [default = false];
+  optional ContactRecordingMode contact_recording_mode = 11 [default = SELECTED_NUMBERS];
 }

--- a/java/com/android/incallui/call/AutoCallRecordingEligibility.kt
+++ b/java/com/android/incallui/call/AutoCallRecordingEligibility.kt
@@ -74,9 +74,7 @@ object AutoCallRecordingEligibility {
       return preferences.autoRecordNonContacts
     }
     val normalizedNumber = entry.normalizedNumber
-    return preferences.autoRecordSelectedNumbersEnabled &&
-        !normalizedNumber.isNullOrEmpty() &&
-        CallRecordingPreferenceValues.containsSelectedNumber(preferences, normalizedNumber)
+    return CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, normalizedNumber)
   }
 
   @JvmStatic

--- a/java/com/android/incallui/call/AutoRecordingDecider.kt
+++ b/java/com/android/incallui/call/AutoRecordingDecider.kt
@@ -80,16 +80,16 @@ internal class AutoRecordingDecider(
       return shouldRecord
     }
 
-    if (!preferences.autoRecordSelectedNumbersEnabled) {
+    if (!preferences.autoRecordContactsEnabled) {
       return false
     }
     val normalizedNumber = entry.normalizedNumber
     if (!normalizedNumber.isNullOrEmpty()) {
       val shouldRecord =
-          CallRecordingPreferenceValues.containsSelectedNumber(preferences, normalizedNumber)
+          CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, normalizedNumber)
       LogUtil.i(
           "$TAG.shouldAutoRecord",
-          "Automatic recording selected number decision, shouldRecord=%b",
+          "Automatic recording contact number decision, shouldRecord=%b",
           shouldRecord)
       return shouldRecord
     }
@@ -112,7 +112,7 @@ internal class AutoRecordingDecider(
           LogUtil.e(TAG, "Automatic recording fallback normalization failed", e)
           return false
         }
-    return CallRecordingPreferenceValues.containsSelectedNumber(preferences, canonicalNumber)
+    return CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, canonicalNumber)
   }
 
   companion object {

--- a/tests/integration/src/com/android/dialer/integration/AutoCallRecordingIntegrationTestBase.java
+++ b/tests/integration/src/com/android/dialer/integration/AutoCallRecordingIntegrationTestBase.java
@@ -702,7 +702,7 @@ abstract class AutoCallRecordingIntegrationTestBase {
             .setCallRecordingOutputFormatV2(RecordingOutputFormat.LPCM_WAV)
             .setRecordingWarningPresented(true)
             .setAutoRecordingSetAtLeastOnce(true)
-            .setAutoRecordSelectedNumbersEnabled(true);
+            .setAutoRecordContactsEnabled(true);
     CallRecordingPreferenceValues.setSelectedNumbers(
         builder, new HashSet<>(Arrays.asList(selectedNumbers)));
     writeCallRecordingPreferences(builder.build());

--- a/tests/integration/src/com/android/dialer/integration/ContactRecordingSettingsIntegrationTest.java
+++ b/tests/integration/src/com/android/dialer/integration/ContactRecordingSettingsIntegrationTest.java
@@ -1,0 +1,195 @@
+package com.android.dialer.integration;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.content.Intent;
+import android.os.SystemClock;
+import android.view.WindowManager;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject2;
+import androidx.test.uiautomator.Until;
+import com.android.dialer.app.R;
+import com.android.dialer.app.settings.AutoCallRecordingSelectedNumbersActivity;
+import com.android.dialer.callrecord.CallRecordingPreferences;
+import com.android.dialer.callrecord.CallRecordingPreferencesStore;
+import com.android.dialer.callrecord.ContactRecordingMode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public final class ContactRecordingSettingsIntegrationTest {
+  private static final String NUMBER = "+15551230001";
+  private static final long TIMEOUT_MILLIS = 5000;
+  private Context context;
+  private UiDevice device;
+  private CallRecordingPreferences originalPreferences;
+
+  @Before
+  public void setUp() throws Exception {
+    context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+    device.wakeUp();
+    device.executeShellCommand("wm dismiss-keyguard");
+    KeyguardManager keyguardManager = context.getSystemService(KeyguardManager.class);
+    long deadline = SystemClock.uptimeMillis() + TIMEOUT_MILLIS;
+    while (keyguardManager.isKeyguardLocked() && SystemClock.uptimeMillis() < deadline) {
+      SystemClock.sleep(50);
+    }
+    assertWithMessage("Unlock the device before running settings UI tests")
+        .that(keyguardManager.isKeyguardLocked())
+        .isFalse();
+    assertThat(device.isScreenOn()).isTrue();
+    originalPreferences = CallRecordingPreferencesStore.readBlocking(context);
+  }
+
+  @After
+  public void tearDown() {
+    if (originalPreferences != null) {
+      CallRecordingPreferencesStore.updateBlocking(
+          context, builder -> builder.clear().mergeFrom(originalPreferences));
+    }
+  }
+
+  @Test
+  public void cancelPreservesSelectedNumbersAndMode() {
+    seed(ContactRecordingMode.SELECTED_NUMBERS, true);
+    try (ActivityScenario<AutoCallRecordingSelectedNumbersActivity> scenario = launch()) {
+      chooseMode(R.string.call_recording_contact_mode_all);
+      waitForText(R.string.call_recording_change_mode_title);
+      clickDialogButton(android.R.id.button2);
+
+      assertThat(preferences().getContactRecordingMode())
+          .isEqualTo(ContactRecordingMode.SELECTED_NUMBERS);
+      assertThat(preferences().getAutoRecordSelectedNumbersList()).containsExactly(NUMBER);
+    }
+  }
+
+  @Test
+  public void switchingModesDiscardsSavedNumbersOnlyAfterConfirmation() {
+    for (ContactRecordingMode from :
+        new ContactRecordingMode[] {
+          ContactRecordingMode.SELECTED_NUMBERS, ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS
+        }) {
+      seed(from, true);
+      boolean switchToAll = from == ContactRecordingMode.SELECTED_NUMBERS;
+      try (ActivityScenario<AutoCallRecordingSelectedNumbersActivity> scenario = launch()) {
+        chooseMode(
+            switchToAll
+                ? R.string.call_recording_contact_mode_all
+                : R.string.call_recording_contact_mode_selected);
+        waitForText(R.string.call_recording_change_mode_title);
+        assertThat(preferences().getContactRecordingMode()).isEqualTo(from);
+        assertThat(preferences().getAutoRecordSelectedNumbersList()).containsExactly(NUMBER);
+        clickDialogButton(android.R.id.button1);
+        waitForText(
+            switchToAll
+                ? R.string.call_recording_all_contacts_empty
+                : R.string.call_recording_auto_record_selected_numbers_empty);
+
+        assertThat(preferences().getAutoRecordSelectedNumbersList()).isEmpty();
+        assertThat(preferences().getContactRecordingMode())
+            .isEqualTo(
+                switchToAll
+                    ? ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS
+                    : ContactRecordingMode.SELECTED_NUMBERS);
+        assertThat(preferences().getAutoRecordContactsEnabled()).isFalse();
+      }
+    }
+  }
+
+  @Test
+  public void emptyListSwitchesWithoutDiscardDialog() {
+    seed(ContactRecordingMode.SELECTED_NUMBERS, false);
+    try (ActivityScenario<AutoCallRecordingSelectedNumbersActivity> scenario = launch()) {
+      chooseMode(R.string.call_recording_contact_mode_all);
+      waitForText(R.string.call_recording_all_contacts_empty);
+
+      assertThat(
+              device.hasObject(
+                  By.text(context.getString(R.string.call_recording_change_mode_title))))
+          .isFalse();
+      assertThat(preferences().getContactRecordingMode())
+          .isEqualTo(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS);
+    }
+  }
+
+  @Test
+  public void backDismissesConfirmationWithoutChangingExceptions() {
+    seed(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS, true);
+    try (ActivityScenario<AutoCallRecordingSelectedNumbersActivity> scenario = launch()) {
+      chooseMode(R.string.call_recording_contact_mode_selected);
+      waitForText(R.string.call_recording_change_mode_title);
+      device.pressBack();
+      device.waitForIdle();
+
+      assertThat(preferences().getContactRecordingMode())
+          .isEqualTo(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS);
+      assertThat(preferences().getAutoRecordSelectedNumbersList()).containsExactly(NUMBER);
+    }
+  }
+
+  private void seed(ContactRecordingMode mode, boolean withNumber) {
+    CallRecordingPreferencesStore.updateBlocking(
+        context,
+        builder -> {
+          builder
+              .setAutoRecordContactsEnabled(false)
+              .setContactRecordingMode(mode)
+              .clearAutoRecordSelectedNumbers();
+          if (withNumber) {
+            builder.addAutoRecordSelectedNumbers(NUMBER);
+          }
+        });
+  }
+
+  private ActivityScenario<AutoCallRecordingSelectedNumbersActivity> launch() {
+    ActivityScenario<AutoCallRecordingSelectedNumbersActivity> scenario =
+        ActivityScenario.launch(
+            new Intent(context, AutoCallRecordingSelectedNumbersActivity.class));
+    scenario.onActivity(
+        activity -> activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON));
+    return scenario;
+  }
+
+  private CallRecordingPreferences preferences() {
+    return CallRecordingPreferencesStore.readBlocking(context);
+  }
+
+  private void chooseMode(int label) {
+    click(R.string.call_recording_contact_mode_title);
+    click(label);
+  }
+
+  private void click(int text) {
+    waitForText(text).click();
+    device.waitForIdle();
+  }
+
+  private UiObject2 waitForText(int text) {
+    UiObject2 view =
+        device.wait(Until.findObject(By.text(context.getString(text))), TIMEOUT_MILLIS);
+    assertThat(view).isNotNull();
+    return view;
+  }
+
+  private void clickDialogButton(int buttonId) {
+    UiObject2 button =
+        device.wait(
+            Until.findObject(
+                By.res(context.getResources().getResourceName(buttonId))
+                    .pkg(context.getPackageName())),
+            TIMEOUT_MILLIS);
+    assertThat(button).isNotNull();
+    button.click();
+    device.waitForIdle();
+  }
+}

--- a/tests/src/com/android/dialer/callrecord/AutoCallRecordingStaleContactCleanerTest.kt
+++ b/tests/src/com/android/dialer/callrecord/AutoCallRecordingStaleContactCleanerTest.kt
@@ -119,6 +119,41 @@ class AutoCallRecordingStaleContactCleanerTest {
   }
 
   @Test
+  fun cleanupPreservesExceptionsAndDoesNotScheduleLookups() = runTest {
+    writeSettings(true, setOf(STALE_NUMBER))
+    val preferences =
+        CallRecordingPreferencesStore.update(context) {
+          it.setContactRecordingMode(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS)
+        }
+
+    val result =
+        AutoCallRecordingStaleContactCleaner.clean(context) { _, _ ->
+          throw AssertionError("Exceptions must not be pruned")
+        }
+
+    assertThat(getSelectedNumbers()).containsExactly(STALE_NUMBER)
+    assertThat(result.changed).isFalse()
+    assertThat(AutoCallRecordingStaleContactCleanupJobService.shouldScheduleCleanup(preferences))
+        .isFalse()
+  }
+
+  @Test
+  fun cleanupCannotRemoveExceptionsAfterAModeChangeDuringLookup() = runTest {
+    writeSettings(true, setOf(STALE_NUMBER))
+
+    val result =
+        AutoCallRecordingStaleContactCleaner.clean(context) { _, selectedNumbers ->
+          CallRecordingPreferencesStore.update(context) {
+            it.setContactRecordingMode(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS)
+          }
+          resolveResult(selectedNumbers, STALE_NUMBER)
+        }
+
+    assertThat(getSelectedNumbers()).containsExactly(STALE_NUMBER)
+    assertThat(result.changed).isFalse()
+  }
+
+  @Test
   fun cleanupIsScheduledOnlyWhenSelectedNumberRecordingHasStoredNumbers() {
     writeSettings(false, setOf(LOCAL_NUMBER))
     CallRecordingPreferencesStore.updateBlocking(context) { builder ->
@@ -216,7 +251,7 @@ class AutoCallRecordingStaleContactCleanerTest {
   ) {
     CallRecordingPreferencesStore.updateBlocking(context) { builder ->
       builder
-          .setAutoRecordSelectedNumbersEnabled(selectedNumberRecordingEnabled)
+          .setAutoRecordContactsEnabled(selectedNumberRecordingEnabled)
           .setAutoRecordingSetAtLeastOnce(true)
       CallRecordingPreferenceValues.setSelectedNumbers(builder, selectedNumbers)
     }

--- a/tests/src/com/android/dialer/callrecord/CallRecordingPreferencesStoreTest.java
+++ b/tests/src/com/android/dialer/callrecord/CallRecordingPreferencesStoreTest.java
@@ -150,7 +150,7 @@ public final class CallRecordingPreferencesStoreTest {
 
     CallRecordingPreferences preferences = CallRecordingPreferencesStore.readBlocking(context);
     assertThat(preferences.getAutoRecordNonContacts()).isFalse();
-    assertThat(preferences.getAutoRecordSelectedNumbersEnabled()).isFalse();
+    assertThat(preferences.getAutoRecordContactsEnabled()).isFalse();
     assertThat(CallRecordingPreferenceValues.selectedNumbers(preferences)).isEmpty();
     assertThat(preferences.getAutoRecordingSetAtLeastOnce()).isFalse();
     assertThat(preferences.getRecordingWarningPresented()).isFalse();

--- a/tests/src/com/android/dialer/callrecord/ContactRecordingModeTest.kt
+++ b/tests/src/com/android/dialer/callrecord/ContactRecordingModeTest.kt
@@ -1,0 +1,125 @@
+package com.android.dialer.callrecord
+
+import com.android.dialer.callrecord.ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS
+import com.android.dialer.callrecord.ContactRecordingMode.SELECTED_NUMBERS
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ContactRecordingModeTest {
+  @Test
+  fun upgradingPreservesEnabledContactRecording() {
+    // Wire field 7 was auto_record_selected_numbers_enabled before it was renamed.
+    val preferences = CallRecordingPreferences.parseFrom(byteArrayOf(0x38, 0x01))
+
+    assertThat(preferences.autoRecordContactsEnabled).isTrue()
+    assertThat(preferences.contactRecordingMode).isEqualTo(SELECTED_NUMBERS)
+    assertThat(preferences.hasContactRecordingMode()).isFalse()
+  }
+
+  @Test
+  fun selectedModeRecordsOnlyListedContactNumbers() {
+    val preferences = preferences(SELECTED_NUMBERS).addAutoRecordSelectedNumbers(NUMBER).build()
+
+    assertThat(CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, NUMBER))
+        .isTrue()
+    assertThat(CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, OTHER_NUMBER))
+        .isFalse()
+  }
+
+  @Test
+  fun exceptionModeRecordsOnlyUnlistedContactNumbers() {
+    val preferences =
+        preferences(ALL_EXCEPT_SELECTED_NUMBERS).addAutoRecordSelectedNumbers(NUMBER).build()
+
+    assertThat(CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, NUMBER))
+        .isFalse()
+    assertThat(CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, OTHER_NUMBER))
+        .isTrue()
+  }
+
+  @Test
+  fun emptyListRecordsAllContactsOnlyInExceptionMode() {
+    assertThat(
+        CallRecordingPreferenceValues.shouldRecordContactNumber(
+            preferences(SELECTED_NUMBERS).build(), NUMBER))
+        .isFalse()
+    assertThat(
+        CallRecordingPreferenceValues.shouldRecordContactNumber(
+            preferences(ALL_EXCEPT_SELECTED_NUMBERS).build(), NUMBER))
+        .isTrue()
+  }
+
+  @Test
+  fun turningOffContactRecordingStopsRecordingUnlistedContacts() {
+    val preferences =
+        preferences(ALL_EXCEPT_SELECTED_NUMBERS)
+            .addAutoRecordSelectedNumbers(NUMBER)
+            .setAutoRecordContactsEnabled(false)
+            .build()
+
+    assertThat(CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, OTHER_NUMBER))
+        .isFalse()
+  }
+
+  @Test
+  fun contactsWithoutAUsableNumberAreNotRecorded() {
+    val preferences = preferences(ALL_EXCEPT_SELECTED_NUMBERS).build()
+
+    assertThat(CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, null)).isFalse()
+    assertThat(CallRecordingPreferenceValues.shouldRecordContactNumber(preferences, "")).isFalse()
+  }
+
+  @Test
+  fun switchingEitherDirectionClearsNumbersAndPreservesEnablement() {
+    val transitions = listOf(
+        SELECTED_NUMBERS to ALL_EXCEPT_SELECTED_NUMBERS,
+        ALL_EXCEPT_SELECTED_NUMBERS to SELECTED_NUMBERS)
+    for ((from, to) in transitions) {
+      val builder = preferences(from).addAutoRecordSelectedNumbers(NUMBER)
+      CallRecordingPreferenceValues.switchContactRecordingMode(builder, from, setOf(NUMBER), to)
+      val saved = CallRecordingPreferences.parseFrom(builder.build().toByteArray())
+
+      assertThat(saved.contactRecordingMode).isEqualTo(to)
+      assertThat(saved.autoRecordSelectedNumbersList).isEmpty()
+      assertThat(saved.autoRecordContactsEnabled).isTrue()
+    }
+  }
+
+  @Test
+  fun confirmingAnOldListDoesNotDiscardNewNumbers() {
+    val builder =
+        preferences(SELECTED_NUMBERS)
+            .addAutoRecordSelectedNumbers(NUMBER)
+            .addAutoRecordSelectedNumbers(OTHER_NUMBER)
+    val before = builder.build()
+
+    assertThrows(IllegalStateException::class.java) {
+      CallRecordingPreferenceValues.switchContactRecordingMode(
+          builder, SELECTED_NUMBERS, setOf(NUMBER), ALL_EXCEPT_SELECTED_NUMBERS)
+    }
+    assertThat(builder.build()).isEqualTo(before)
+  }
+
+  @Test
+  fun confirmingAnOldChoiceDoesNotClearTheNewMode() {
+    val builder = preferences(ALL_EXCEPT_SELECTED_NUMBERS).addAutoRecordSelectedNumbers(NUMBER)
+    val before = builder.build()
+
+    assertThrows(IllegalStateException::class.java) {
+      CallRecordingPreferenceValues.switchContactRecordingMode(
+          builder, SELECTED_NUMBERS, setOf(NUMBER), ALL_EXCEPT_SELECTED_NUMBERS)
+    }
+    assertThat(builder.build()).isEqualTo(before)
+  }
+
+  private fun preferences(mode: ContactRecordingMode) =
+      CallRecordingPreferences.newBuilder()
+          .setAutoRecordContactsEnabled(true)
+          .setContactRecordingMode(mode)
+
+  private companion object {
+    const val NUMBER = "+15551230001"
+    const val OTHER_NUMBER = "+15551230002"
+  }
+}

--- a/tests/src/com/android/incallui/AnswerScreenPresenterTest.java
+++ b/tests/src/com/android/incallui/AnswerScreenPresenterTest.java
@@ -264,7 +264,7 @@ public final class AnswerScreenPresenterTest {
     CallRecordingPreferencesStore.updateBlocking(
         context,
         builder -> {
-          builder.setAutoRecordSelectedNumbersEnabled(true);
+          builder.setAutoRecordContactsEnabled(true);
           builder.addAutoRecordSelectedNumbers(normalizedNumber);
         });
   }

--- a/tests/src/com/android/incallui/call/CallRecordingEngineTest.java
+++ b/tests/src/com/android/incallui/call/CallRecordingEngineTest.java
@@ -9,6 +9,7 @@ import static com.google.common.truth.Truth.assertThat;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.android.dialer.callrecord.CallRecordingPreferences;
+import com.android.dialer.callrecord.ContactRecordingMode;
 import com.android.incallui.call.AutoCallRecordingEligibility.AutoRecordDecision;
 import com.android.incallui.call.CallRecordingTestSupport.FakeCurrentCalls;
 import com.android.incallui.call.CallRecordingTestSupport.FakeRecorder;
@@ -125,7 +126,7 @@ public final class CallRecordingEngineTest {
                         new FakeCurrentCalls(activeCall(true /* isConferenceCall */)),
                         contactLookup(new ContactInfo(true /* isLocalContact */, "+15551234567")),
                         preferencesBuilder()
-                            .setAutoRecordSelectedNumbersEnabled(true)
+                            .setAutoRecordContactsEnabled(true)
                             .addAutoRecordSelectedNumbers("+15551234567")
                             .build())
                     .onRecorderServiceConnected());
@@ -145,7 +146,7 @@ public final class CallRecordingEngineTest {
             contactLookup(new ContactInfo(true /* isLocalContact */, "+15557654321")),
             preferencesBuilder()
                 .setAutoRecordNonContacts(true)
-                .setAutoRecordSelectedNumbersEnabled(true)
+                .setAutoRecordContactsEnabled(true)
                 .addAutoRecordSelectedNumbers("+15557654321")
                 .build());
     DialerCall privateConferenceChild = conferenceChildCall("call-1", null);
@@ -172,7 +173,7 @@ public final class CallRecordingEngineTest {
             currentCalls,
             new MatchingNumberTestContactLookup(),
             preferencesBuilder()
-                .setAutoRecordSelectedNumbersEnabled(true)
+                .setAutoRecordContactsEnabled(true)
                 .addAutoRecordSelectedNumbers("+15557654321")
                 .build());
     DialerCall nonEligibleCall = call("call-1", DialerCallState.ACTIVE, "+15550000000");
@@ -282,7 +283,7 @@ public final class CallRecordingEngineTest {
             new FakeCurrentCalls(activeCall("call-2", "+15557654321")),
             contactLookup(new ContactInfo(true /* isLocalContact */, "+15557654321")),
             preferencesBuilder()
-                .setAutoRecordSelectedNumbersEnabled(true)
+                .setAutoRecordContactsEnabled(true)
                 .addAutoRecordSelectedNumbers("+15557654321")
                 .build());
     DialerCall heldDialerCall = call("call-1", DialerCallState.ONHOLD, null);
@@ -835,7 +836,7 @@ public final class CallRecordingEngineTest {
                         new FakeCurrentCalls(activeCall()),
                         contactLookup(new ContactInfo(true /* isLocalContact */, "+15551234567")),
                         preferencesBuilder()
-                            .setAutoRecordSelectedNumbersEnabled(true)
+                            .setAutoRecordContactsEnabled(true)
                             .addAutoRecordSelectedNumbers("+15551234567")
                             .build())
                     .onRecorderServiceConnected());
@@ -843,6 +844,71 @@ public final class CallRecordingEngineTest {
     assertThat(recorder.awaitArmed()).isTrue();
     assertThat(recorder.armedCallId).isEqualTo("call-1");
     assertThat(recorder.armedAutomatically).isTrue();
+  }
+
+  @Test
+  public void allContactsPolicyStartsRecordingWithNoExceptions() throws Exception {
+    FakeRecorder recorder = new FakeRecorder();
+
+    InstrumentationRegistry.getInstrumentation()
+        .runOnMainSync(
+            () ->
+                newEngine(
+                        recorder,
+                        new FakeCurrentCalls(activeCall()),
+                        contactLookup(new ContactInfo(true, "+15551234567")),
+                        preferencesBuilder()
+                            .setAutoRecordContactsEnabled(true)
+                            .setContactRecordingMode(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS)
+                            .build())
+                    .onRecorderServiceConnected());
+
+    assertThat(recorder.awaitArmed()).isTrue();
+    assertThat(recorder.armedAutomatically).isTrue();
+  }
+
+  @Test
+  public void excludedContactDoesNotRecordEvenWhenNonContactRecordingIsEnabled() {
+    FakeRecorder recorder = new FakeRecorder();
+
+    InstrumentationRegistry.getInstrumentation()
+        .runOnMainSync(
+            () ->
+                newEngine(
+                        recorder,
+                        new FakeCurrentCalls(activeCall()),
+                        contactLookup(new ContactInfo(true, "+15551234567")),
+                        preferencesBuilder()
+                            .setAutoRecordContactsEnabled(true)
+                            .setAutoRecordNonContacts(true)
+                            .setContactRecordingMode(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS)
+                            .addAutoRecordSelectedNumbers("+15551234567")
+                            .build())
+                    .onRecorderServiceConnected());
+
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+    assertThat(recorder.armedCallId).isNull();
+  }
+
+  @Test
+  public void allContactsPolicyDoesNotEnableNonContactRecording() {
+    FakeRecorder recorder = new FakeRecorder();
+
+    InstrumentationRegistry.getInstrumentation()
+        .runOnMainSync(
+            () ->
+                newEngine(
+                        recorder,
+                        new FakeCurrentCalls(activeCall()),
+                        noContact(),
+                        preferencesBuilder()
+                            .setAutoRecordContactsEnabled(true)
+                            .setContactRecordingMode(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS)
+                            .build())
+                    .onRecorderServiceConnected());
+
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+    assertThat(recorder.armedCallId).isNull();
   }
 
   @Test


### PR DESCRIPTION
The list becomes a list of numbers to not record.

This preserves the original setting being an allowlist of contacts via reusing protobuf fields in the DataStore. That is, on app update, if a user has enabled auto recording for selected contacts, it will remain as auto recording for those contacts after the Dialer app is updated.