### PR TITLE
callrec: declare microphone and phone foreground service type

### DIFF
--- a/java/com/android/incallui/AndroidManifest.xml
+++ b/java/com/android/incallui/AndroidManifest.xml
@@ -30,6 +30,8 @@
   <uses-permission android:name="android.permission.CAMERA"/>
 
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL"/>
 
   <!-- Warning: setting the required boolean to true would prevent installation of Dialer on
        devices which do not support a camera. -->
@@ -85,6 +87,7 @@
     <service
         android:directBootAware="true"
         android:exported="true"
+        android:foregroundServiceType="phoneCall|microphone"
         android:name="com.android.incallui.InCallServiceImpl"
         android:permission="android.permission.BIND_INCALL_SERVICE">
       <meta-data


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8683

Auto call recording was working in most configurations since the UI was actually brought up.
However, answering from Bluetooth didn't show the UI. So:

- If InCallActivity becomes visible/top before automatic recording creates AudioRecord,
  OP_RECORD_AUDIO should be allowed and recording may work.
- If the call becomes ACTIVE first, particularly while locked, screen off, or the activity launch is
  delayed, automatic recording can start while Dialer lacks foreground microphone capability.
  Audioserver will then permanently silence that recording. Bluetooth answer while phone is unlocked
  also doesn't show the UI

Android aggregates process capabilities at UID level, so InCallServiceImpl’s microphone capability
satisfies the recording services' OP_RECORD_AUDIO check

Test: manual, answer incoming phone call from Bluetooth with phone unlocked and auto call record on,
check that the recording isn't silent