### PR TITLE
callrec: default auto call recording contact mode to all contacts for new users

### DIFF
--- a/java/com/android/dialer/callrecord/CallRecordingPreferencesStore.kt
+++ b/java/com/android/dialer/callrecord/CallRecordingPreferencesStore.kt
@@ -35,6 +35,9 @@ import kotlinx.coroutines.runBlocking
 /** Credential encrypted, multi-process storage for call recording preferences. */
 object CallRecordingPreferencesStore {
 
+  private const val MIGRATE_SETTINGS_LOG_TAG = "CallRecordingPreferencesStore.migrateSettings"
+  private const val CURRENT_SETTINGS_VERSION = 1
+
   const val KEY_CALL_RECORDING_USE_V2 = "call_recording_use_v2"
   const val KEY_CALL_RECORDING_AUDIO_SOURCE = "call_recording_audio_source"
   const val KEY_CALL_RECORDING_OUTPUT_FORMAT = "call_recording_output_format"
@@ -195,10 +198,17 @@ object CallRecordingPreferencesStore {
     val preferences =
         DEFAULT_PREFERENCES.toBuilder()
             .setSharedPreferencesMigrated(sharedPreferencesMigrated)
+            .setSettingsVersion(CURRENT_SETTINGS_VERSION)
             .build()
     runDataStoreBlocking { updatePreferencesWithoutMigrationSuspend(context) { preferences } }
     resetDataStoreForTesting()
   }
+
+  @VisibleForTesting
+  @JvmStatic
+  fun migrateSettingsForTesting(
+      preferences: CallRecordingPreferences
+  ): CallRecordingPreferences = migrateSettings(preferences)
 
   @WorkerThread
   private fun readPreferencesOrDefault(context: Context): CallRecordingPreferences {
@@ -322,7 +332,10 @@ object CallRecordingPreferencesStore {
                           exception)
                       DEFAULT_PREFERENCES
                     },
-                migrations = listOf(LegacySharedPreferencesMigration(appContext)),
+                migrations = listOf(
+                    LegacySharedPreferencesMigration(appContext),
+                    SettingsVersionMigration(),
+                ),
                 scope = dataStoreScope(appContext),
                 produceFile = { appContext.dataStoreFile(DATASTORE_FILE_NAME) })
         dataStore = current
@@ -416,6 +429,38 @@ object CallRecordingPreferencesStore {
     return context.applicationContext ?: context
   }
 
+  // New installs begin at settings version 0, so all versioned settings migrations run for them.
+  private fun migrateSettings(preferences: CallRecordingPreferences): CallRecordingPreferences {
+    if (preferences.settingsVersion >= CURRENT_SETTINGS_VERSION) {
+      return preferences
+    }
+    val builder = preferences.toBuilder()
+    var version = preferences.settingsVersion
+    while (version < CURRENT_SETTINGS_VERSION) {
+      LogUtil.i(
+          MIGRATE_SETTINGS_LOG_TAG,
+          "updating call recording settings from version $version to version ${version + 1}")
+      version++
+      when (version) {
+        1 -> {
+          if (!builder.autoRecordingSetAtLeastOnce) {
+            builder.setContactRecordingMode(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS)
+            LogUtil.i(
+                MIGRATE_SETTINGS_LOG_TAG,
+                "defaulted contact recording mode to all contacts")
+          } else {
+            LogUtil.i(
+                MIGRATE_SETTINGS_LOG_TAG,
+                "preserved contact recording mode because automatic recording was configured")
+          }
+        }
+        else -> error("Missing call recording settings migration $version")
+      }
+      builder.setSettingsVersion(version)
+    }
+    return builder.build()
+  }
+
   private class LegacySharedPreferencesMigration(private val context: Context) :
       DataMigration<CallRecordingPreferences> {
     override suspend fun shouldMigrate(currentData: CallRecordingPreferences): Boolean {
@@ -434,5 +479,17 @@ object CallRecordingPreferencesStore {
     override suspend fun cleanUp() {
       CallRecordingPreferencesStore.clearMigratedSharedPreferencesKeys(context)
     }
+  }
+
+  private class SettingsVersionMigration : DataMigration<CallRecordingPreferences> {
+    override suspend fun shouldMigrate(currentData: CallRecordingPreferences): Boolean {
+      return currentData.settingsVersion < CURRENT_SETTINGS_VERSION
+    }
+
+    override suspend fun migrate(
+        currentData: CallRecordingPreferences
+    ): CallRecordingPreferences = CallRecordingPreferencesStore.migrateSettings(currentData)
+
+    override suspend fun cleanUp() {}
   }
 }

--- a/java/com/android/dialer/callrecord/call_recording_preferences.proto
+++ b/java/com/android/dialer/callrecord/call_recording_preferences.proto
@@ -23,8 +23,7 @@ message CallRecordingPreferences {
       [default = AAC_MPEG_4];
   optional RecordingOutputFormat call_recording_output_format_v2 = 4
       [default = AAC_MPEG_4];
-  // One-time marker for the legacy SharedPreferences import. Add a broader migration version only
-  // when there is a second durable migration to distinguish.
+  // One-time marker for the legacy SharedPreferences import.
   optional bool shared_preferences_migrated = 5 [default = false];
   optional bool auto_record_non_contacts = 6 [default = false];
   // Enables contact recording in either contact_recording_mode.
@@ -33,5 +32,8 @@ message CallRecordingPreferences {
   repeated string auto_record_selected_numbers = 8;
   optional bool auto_recording_set_at_least_once = 9 [default = false];
   optional bool recording_warning_presented = 10 [default = false];
+  // Defaults to ALL_EXCEPT_SELECTED_NUMBERS for new installs via settings migration.
   optional ContactRecordingMode contact_recording_mode = 11 [default = SELECTED_NUMBERS];
+  // See CallRecordingPreferencesStore for versioning and migration details.
+  optional uint32 settings_version = 12 [default = 0];
 }

--- a/tests/src/com/android/dialer/callrecord/CallRecordingPreferencesStoreTest.java
+++ b/tests/src/com/android/dialer/callrecord/CallRecordingPreferencesStoreTest.java
@@ -157,6 +157,52 @@ public final class CallRecordingPreferencesStoreTest {
   }
 
   @Test
+  public void neverConfiguredUserDefaultsToAllContacts() {
+    CallRecordingPreferences preferences =
+        CallRecordingPreferencesStore.migrateSettingsForTesting(
+            CallRecordingPreferences.getDefaultInstance());
+
+    assertThat(preferences)
+        .isEqualTo(
+            CallRecordingPreferences.newBuilder()
+                .setContactRecordingMode(ContactRecordingMode.ALL_EXCEPT_SELECTED_NUMBERS)
+                .setSettingsVersion(1)
+                .build());
+  }
+
+  @Test
+  public void previouslyConfiguredUserKeepsAutomaticRecordingSettings() {
+    CallRecordingPreferences preferences =
+        CallRecordingPreferences.newBuilder()
+            .setAutoRecordingSetAtLeastOnce(true)
+            .setContactRecordingMode(ContactRecordingMode.SELECTED_NUMBERS)
+            .addAutoRecordSelectedNumbers("+15551230001")
+            .build();
+
+    CallRecordingPreferences migrated =
+        CallRecordingPreferencesStore.migrateSettingsForTesting(preferences);
+
+    assertThat(migrated)
+        .isEqualTo(preferences.toBuilder().setSettingsVersion(1).build());
+  }
+
+  @Test
+  public void currentSettingsVersionIsNotMigratedAgain() {
+    CallRecordingPreferences currentPreferences =
+        CallRecordingPreferencesStore.migrateSettingsForTesting(
+            CallRecordingPreferences.getDefaultInstance());
+    CallRecordingPreferences preferences =
+        currentPreferences.toBuilder()
+            .setContactRecordingMode(ContactRecordingMode.SELECTED_NUMBERS)
+            .build();
+
+    CallRecordingPreferences migrated =
+        CallRecordingPreferencesStore.migrateSettingsForTesting(preferences);
+
+    assertThat(migrated).isEqualTo(preferences);
+  }
+
+  @Test
   public void outputFormatRoundTripsTypedValuesForV1AndV2() {
     CallRecordingPreferencesStore.updateBlocking(
         context,


### PR DESCRIPTION
Existing users who have activated auto call recording at least once will have the auto contact recording mode unchanged

Test: atest DialerTests:com.android.dialer.callrecord.CallRecordingPreferencesStoreTest